### PR TITLE
fix: change daily CI time

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -2,7 +2,9 @@ name: CI [Daily]
 
 on:
   schedule:
-    - cron: '0 0 * * 1-5'
+    # The job will run at 7am UTC
+    # every week day
+    - cron: '0 7 * * 1-5'
   workflow_dispatch: { }
 
 env:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR changes the time when the CI will run.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` to ensure this PR is ready for review
- [ ] Add or update tests
- [ ] Add or update Documentation
- [ ] Update CHANGELOG.md (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
