### PR TITLE
feat: provide access to the crds empedded in the repository

### DIFF
--- a/package/crds/embed.go
+++ b/package/crds/embed.go
@@ -1,0 +1,47 @@
+package crds
+
+import (
+	"embed"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// content holds our CRDs. The embedding happens via the go build tool.
+//go:embed *.yaml
+var crds embed.FS
+
+// MustGetCRDs return the CRDs installed by the crossplane provider
+// The CRDs are read from embedded files.
+// This function can panic in theory but never should in practice.
+func MustGetCRDs() []apiextensionsv1.CustomResourceDefinition {
+	crds, err := GetCRDs()
+	if err != nil {
+		panic(err)
+	}
+	return crds
+}
+
+// GetCRDs return the CRDs installed by the crossplane provider
+// The CRDs are read from embedded files.
+func GetCRDs() ([]apiextensionsv1.CustomResourceDefinition, error) {
+	files, err := crds.ReadDir(".")
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]apiextensionsv1.CustomResourceDefinition, len(files))
+	for i, file := range files {
+		data, err := crds.ReadFile(file.Name())
+		if err != nil {
+			return nil, err
+		}
+		var crd apiextensionsv1.CustomResourceDefinition
+		if err = yaml.Unmarshal(data, &crd); err != nil {
+			return nil, err
+		}
+		ret[i] = crd
+	}
+
+	return ret, nil
+}

--- a/package/crds/embed_test.go
+++ b/package/crds/embed_test.go
@@ -1,0 +1,16 @@
+package crds
+
+import (
+	"testing"
+)
+
+func TestMustGetCRDs(t *testing.T) {
+	MustGetCRDs() // doesn't panic
+}
+
+func TestGetCRDs(t *testing.T) {
+	_, err := GetCRDs()
+	if err != nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
### Description of your changes

This PR adds accessory functionality to get access to the CRDs. This is especially useful in testing scenarios, when you want to deploy the CRDs programmatically.

## Checklist

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- ~Run `make reviewable` to ensure this PR is ready for review~ -> task doesn't exist
- [x] Add or update tests
-  ~Add or update Documentation~ -> not applicable
- ~Update CHANGELOG.md (label: `upcoming release`)~ -> not chagelog
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
