### PR TITLE
Add an explicit CPU family AUTO

### DIFF
--- a/apis/k8s/v1alpha1/nodepool_types.go
+++ b/apis/k8s/v1alpha1/nodepool_types.go
@@ -25,6 +25,10 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 )
 
+// CPUFamilyAuto can be specified to actively instruct the provider to use any available CPU family for a
+// kubernetes NodePool
+const CPUFamilyAuto = "AUTO"
+
 // NodePoolParameters are the observable fields of a NodePool.
 // Required fields in order to create a K8s NodePool:
 // ClusterConfig,

--- a/internal/controller/k8s/k8snodepool/nodepool.go
+++ b/internal/controller/k8s/k8snodepool/nodepool.go
@@ -209,7 +209,8 @@ func (c *externalNodePool) Create(ctx context.Context, mg resource.Managed) (man
 
 	// Note: If the CPU Family is not set by the user, the Crossplane Provider IONOS Cloud
 	// will take the first CPU Family offered by the Datacenter CPU Architectures available
-	if cr.Spec.ForProvider.CPUFamily == "" {
+	// If the user specified explicitly AUTO the same behaviour is applied.
+	if cr.Spec.ForProvider.CPUFamily == "" || cr.Spec.ForProvider.CPUFamily == v1alpha1.CPUFamilyAuto {
 		cpuFamilies, err := c.datacenterService.GetCPUFamiliesForDatacenter(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID)
 		if err != nil {
 			return managed.ExternalCreation{}, fmt.Errorf("failed to get CPU Families AVAILABLE for datacenter. error: %w", err)


### PR DESCRIPTION
This allows user to explicitly set an automatic choosen CPU family. The old implemenation with the empty string
will cause endless churn loops, if the nodepool resource is created by another reconciler which has the empty string as desired value.
This is the case if the user uses ArgoCD or fluxCD.

### Description of your changes

Adds CPU family AUTO to explicitly choose a CPU family.

This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` to ensure this PR is ready for review
- [ ] Add or update tests
- [ ] Add or update Documentation
- [ ] Update CHANGELOG.md (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
