### PR TITLE
feat: Move CPU family from late init to status.

### DIFF
--- a/apis/generate.go
+++ b/apis/generate.go
@@ -1,3 +1,4 @@
+//go:build generate
 // +build generate
 
 /*
@@ -20,7 +21,7 @@ limitations under the License.
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
 // Remove existing CRDs
-//go:generate rm -rf ../package/crds
+//go:generate rm -rf ../package/crds/*.yaml
 
 // Generate deepcopy methodsets and CRD manifests
 //go:generate go run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=../hack/boilerplate.go.txt paths=./... crd:trivialVersions=true,allowDangerousTypes=true,crdVersions=v1 output:artifacts:config=../package/crds

--- a/apis/k8s/v1alpha1/nodepool_types.go
+++ b/apis/k8s/v1alpha1/nodepool_types.go
@@ -296,6 +296,7 @@ type NodePoolObservation struct {
 	State                    string   `json:"state,omitempty"`
 	PublicIPs                []string `json:"publicIps,omitempty"`
 	AvailableUpgradeVersions []string `json:"availableUpgradeVersions,omitempty"`
+	CPUFamily                string   `json:"cpuFamily,omitempty"`
 }
 
 // A NodePoolSpec defines the desired state of a NodePool.

--- a/internal/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/clients/k8s/k8snodepool/nodepool.go
@@ -157,13 +157,6 @@ func LateInitializer(in *v1alpha1.NodePoolParameters, sg *sdkgo.KubernetesNodePo
 				in.K8sVersion = *versionOk
 			}
 		}
-		// Set the CPU Family set by the Crossplane Provider,
-		// if no CPU Family was provided, to be transparent to the user.
-		if cpuFamilyOk, ok := propertiesOk.GetCpuFamilyOk(); ok && cpuFamilyOk != nil {
-			if utils.IsEmptyValue(reflect.ValueOf(in.CPUFamily)) {
-				in.CPUFamily = *cpuFamilyOk
-			}
-		}
 	}
 }
 
@@ -183,7 +176,12 @@ func LateStatusInitializer(in *v1alpha1.NodePoolObservation, sg *sdkgo.Kubernete
 		} else {
 			in.PublicIPs = []string{}
 		}
+
+		if cpuFamilyOk, ok := propertiesOk.GetCpuFamilyOk(); ok && cpuFamilyOk != nil {
+			in.CPUFamily = *cpuFamilyOk
+		}
 	}
+
 }
 
 // IsK8sNodePoolUpToDate returns true if the NodePool is up-to-date or false if it does not

--- a/package/crds/k8s.ionoscloud.crossplane.io_nodepools.yaml
+++ b/package/crds/k8s.ionoscloud.crossplane.io_nodepools.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -443,6 +445,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  cpuFamily:
+                    type: string
                   nodePoolId:
                     type: string
                   publicIps:


### PR DESCRIPTION
The old implementation will cause endless churn loops, if the nodepool resource is created by
another reconciler which has the empty string as desired value.
This is the case if the user uses ArgoCD or fluxCD.

### Description of your changes

Add CPUFamily in `Status.AtProvider`.

This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [x] Run `make reviewable` to ensure this PR is ready for review
- [ ] Add or update tests
- [ ] Add or update Documentation
- [ ] Update CHANGELOG.md (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
