### PR TITLE
feat: Set HostURL from env variable if creds.HostURL is empty 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## upcoming release
+
+- **Features**:
+  - Allow to set a global IONOS_API_URL overwrite in the provider pod via environment variables
+
 ## [1.0.0-beta.2] (June 2022)
 
 - **Features**:

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,22 @@ kubectl create secret generic --namespace crossplane-system example-provider-sec
 _Note_: You can overwrite the default IONOS Cloud API endpoint, by setting the following option in credentials
 struct: `credentials="{\"host_url\":\"${IONOS_API_URL}\"}"`.
 
+_Note_: You can also set the `IONOS_API_URL` environment variable in the `ControllerConfig` of the provider globally for all
+resources. The following snipped shows how to set it globally in the ControllerConfig:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: overwrite-ionos-api-url
+spec:
+  env:
+    - name: IONOS_API_URL
+      value: "${IONOS_API_URL}"
+EOF
+```
+
 ### Configure the Provider
 
 We will create the following `ProviderConfig` to configure credentials for Crossplane Provider for IONOS Cloud:
@@ -93,22 +109,6 @@ EOF
 ```
 
 ## Installation
-
-### Create an Image Pull Secret
-
-Create an Image Pull Secret with your credentials, to be able to pull the Crossplane provider packages from the GitHub
-registry, since the images are currently private. You can export environment variables for GitHub access using:
-
-```bash
-export GITHUB_USERNAME=xxx
-export GITHUB_PERSONAL_ACCESSTOKEN=xxx
-```
-
-Create `Secret`:
-
-```bash
-kubectl create secret --namespace crossplane-system docker-registry package-pull --docker-server ghcr.io --docker-username $GITHUB_USERNAME --docker-password $GITHUB_PERSONAL_ACCESSTOKEN
-```
 
 ### Install Provider
 

--- a/internal/clients/ionoscloud.go
+++ b/internal/clients/ionoscloud.go
@@ -33,7 +33,7 @@ const (
 var ionosAPIEndpoint string
 
 func init() {
-	ionosAPIEndpoint = os.Getenv(ionoscloud.IonosApiUrlEnvVar)
+	ionosAPIEndpoint = os.Getenv(sdkgo.IonosApiUrlEnvVar)
 }
 
 // IonosServices contains ionos clients

--- a/internal/clients/ionoscloud.go
+++ b/internal/clients/ionoscloud.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	ionoscloud "github.com/ionos-cloud/sdk-go-dbaas-postgres"
@@ -27,6 +28,13 @@ const (
 	errGetCreds     = "cannot get credentials"
 	errNewClient    = "cannot create new Service"
 )
+
+// allow to set a default IONOS APIs for all clients via env variable.
+var ionosAPIEndpoint string
+
+func init() {
+	ionosAPIEndpoint = os.Getenv(ionoscloud.IonosApiUrlEnvVar)
+}
 
 // IonosServices contains ionos clients
 type IonosServices struct {
@@ -67,12 +75,17 @@ func NewIonosClients(data []byte) (*IonosServices, error) {
 		}
 	}
 
+	apiHostURL := creds.HostURL
+	if apiHostURL == "" && ionosAPIEndpoint != "" {
+		apiHostURL = ionosAPIEndpoint
+	}
+
 	// DBaaS Postgres Client
-	dbaasPostgresConfig := ionoscloud.NewConfiguration(creds.User, string(decodedPW), creds.Token, creds.HostURL)
+	dbaasPostgresConfig := ionoscloud.NewConfiguration(creds.User, string(decodedPW), creds.Token, apiHostURL)
 	dbaasPostgresConfig.UserAgent = fmt.Sprintf("%v_%v", UserAgent, dbaasPostgresConfig.UserAgent)
 	dbaasPostgresClient := ionoscloud.NewAPIClient(dbaasPostgresConfig)
 	// Compute Engine Client
-	computeEngineConfig := sdkgo.NewConfiguration(creds.User, string(decodedPW), creds.Token, creds.HostURL)
+	computeEngineConfig := sdkgo.NewConfiguration(creds.User, string(decodedPW), creds.Token, apiHostURL)
 	computeEngineConfig.UserAgent = fmt.Sprintf("%v_%v", UserAgent, computeEngineConfig.UserAgent)
 	computeEngineClient := sdkgo.NewAPIClient(computeEngineConfig)
 

--- a/internal/clients/ionoscloud.go
+++ b/internal/clients/ionoscloud.go
@@ -32,8 +32,15 @@ const (
 // allow to set a default IONOS APIs for all clients via env variable.
 var ionosAPIEndpoint string
 
-func init() {
+// loadEnv is an indirection from the init function. The init function itself is not callable, but the loadEnv function.
+// This allows us to reset the env before and after each test.
+func loadEnv() {
 	ionosAPIEndpoint = os.Getenv(sdkgo.IonosApiUrlEnvVar)
+
+}
+
+func init() {
+	loadEnv()
 }
 
 // IonosServices contains ionos clients

--- a/internal/clients/ionoscloud_test.go
+++ b/internal/clients/ionoscloud_test.go
@@ -1,0 +1,153 @@
+package clients
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	ionosdbaas "github.com/ionos-cloud/sdk-go-dbaas-postgres"
+	ionos "github.com/ionos-cloud/sdk-go/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	expectedUserAgentCompute = "crossplane-provider-ionoscloud_ionos-cloud-sdk-go/v6.0.4"
+	expectedUserAgentDbaas   = "crossplane-provider-ionoscloud_ionos-cloud-sdk-go-dbaas-postgres/vv1.0.3"
+)
+
+func TestNewIonosClient(t *testing.T) {
+
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name              string
+		args              args
+		env               map[string]string
+		wantComputeConfig *ionos.Configuration
+		wantDbaasConfig   *ionosdbaas.Configuration
+		wantErr           bool
+	}{
+		{
+			name:              "nil data",
+			args:              args{data: nil},
+			wantComputeConfig: nil,
+			wantErr:           true,
+		},
+		{
+			name: "basic auth",
+			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ="}`)},
+			wantComputeConfig: func() *ionos.Configuration {
+				cfg := ionos.NewConfiguration("username", "password", "", "")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentCompute
+				return cfg
+			}(),
+			wantDbaasConfig: func() *ionosdbaas.Configuration {
+				cfg := ionosdbaas.NewConfiguration("username", "password", "", "")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentDbaas
+				return cfg
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "2fa token auth and host url",
+			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token", "host_url":"https://host"}`)},
+			wantComputeConfig: func() *ionos.Configuration {
+				cfg := ionos.NewConfiguration("username", "password", "token", "https://host")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentCompute
+				return cfg
+			}(),
+			wantDbaasConfig: func() *ionosdbaas.Configuration {
+				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "https://host")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentDbaas
+				return cfg
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "2fa token auth and global host url",
+			env:  map[string]string{"IONOS_API_URL": "http://host-from-env"},
+			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token"}`)},
+			wantComputeConfig: func() *ionos.Configuration {
+				cfg := ionos.NewConfiguration("username", "password", "token", "http://host-from-env")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentCompute
+				return cfg
+			}(),
+			wantDbaasConfig: func() *ionosdbaas.Configuration {
+				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "http://host-from-env")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentDbaas
+				return cfg
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "2fa token auth dont overwrite secret specific with global host url",
+			env:  map[string]string{"IONOS_API_URL": "http://host-from-env"},
+			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token", "host_url":"https://host"}`)},
+			wantComputeConfig: func() *ionos.Configuration {
+				cfg := ionos.NewConfiguration("username", "password", "token", "https://host")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentCompute
+				return cfg
+			}(),
+			wantDbaasConfig: func() *ionosdbaas.Configuration {
+				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "https://host")
+				cfg.HTTPClient = http.DefaultClient
+				cfg.UserAgent = expectedUserAgentDbaas
+				return cfg
+			}(),
+			wantErr: false,
+		},
+		{
+			name:              "malformed json",
+			args:              args{data: []byte(`{"user": "foo",`)},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "malformed base64 password",
+			args: args{
+				data: []byte(`{"user": "username","password": "cGFzc3dvcm", "token": "token", "host_url": "foo"}`),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for name, value := range tt.env {
+				require.NoError(t, os.Setenv(name, value))
+			}
+			loadEnv()
+			defer func() {
+				for name := range tt.env {
+					require.NoError(t, os.Unsetenv(name))
+				}
+				loadEnv()
+			}()
+
+			got, err := NewIonosClients(tt.args.data)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+			if tt.wantComputeConfig != nil {
+				require.NotNil(t, got)
+				assert.Equal(t, tt.wantComputeConfig, got.ComputeClient.GetConfig())
+				assert.Equal(t, tt.wantDbaasConfig, got.DBaaSPostgresClient.GetConfig())
+			} else {
+				assert.Nil(t, got)
+			}
+		})
+	}
+}

--- a/internal/clients/ionoscloud_test.go
+++ b/internal/clients/ionoscloud_test.go
@@ -14,6 +14,9 @@ import (
 const (
 	expectedUserAgentCompute = "crossplane-provider-ionoscloud_ionos-cloud-sdk-go/v6.0.4"
 	expectedUserAgentDbaas   = "crossplane-provider-ionoscloud_ionos-cloud-sdk-go-dbaas-postgres/vv1.0.3"
+
+	hostnameFromSecret = "https://host"
+	hostnameFromEnv    = "http://host-from-env"
 )
 
 func setComputeDefaults(cfg *ionos.Configuration) {
@@ -64,12 +67,12 @@ func TestNewIonosClient(t *testing.T) {
 			name: "2fa token auth and host url",
 			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token", "host_url":"https://host"}`)},
 			wantComputeConfig: func() *ionos.Configuration {
-				cfg := ionos.NewConfiguration("username", "password", "token", "https://host")
+				cfg := ionos.NewConfiguration("username", "password", "token", hostnameFromSecret)
 				setComputeDefaults(cfg)
 				return cfg
 			}(),
 			wantDbaasConfig: func() *ionosdbaas.Configuration {
-				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "https://host")
+				cfg := ionosdbaas.NewConfiguration("username", "password", "token", hostnameFromSecret)
 				setDbaaSDefaults(cfg)
 				return cfg
 			}(),
@@ -80,12 +83,12 @@ func TestNewIonosClient(t *testing.T) {
 			env:  map[string]string{"IONOS_API_URL": "http://host-from-env"},
 			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token"}`)},
 			wantComputeConfig: func() *ionos.Configuration {
-				cfg := ionos.NewConfiguration("username", "password", "token", "http://host-from-env")
+				cfg := ionos.NewConfiguration("username", "password", "token", hostnameFromEnv)
 				setComputeDefaults(cfg)
 				return cfg
 			}(),
 			wantDbaasConfig: func() *ionosdbaas.Configuration {
-				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "http://host-from-env")
+				cfg := ionosdbaas.NewConfiguration("username", "password", "token", hostnameFromEnv)
 				setDbaaSDefaults(cfg)
 				return cfg
 			}(),
@@ -93,15 +96,15 @@ func TestNewIonosClient(t *testing.T) {
 		},
 		{
 			name: "2fa token auth dont overwrite secret specific with global host url",
-			env:  map[string]string{"IONOS_API_URL": "http://host-from-env"},
+			env:  map[string]string{"IONOS_API_URL": hostnameFromEnv},
 			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token", "host_url":"https://host"}`)},
 			wantComputeConfig: func() *ionos.Configuration {
-				cfg := ionos.NewConfiguration("username", "password", "token", "https://host")
+				cfg := ionos.NewConfiguration("username", "password", "token", hostnameFromSecret)
 				setComputeDefaults(cfg)
 				return cfg
 			}(),
 			wantDbaasConfig: func() *ionosdbaas.Configuration {
-				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "https://host")
+				cfg := ionosdbaas.NewConfiguration("username", "password", "token", hostnameFromSecret)
 				setDbaaSDefaults(cfg)
 				return cfg
 			}(),

--- a/internal/clients/ionoscloud_test.go
+++ b/internal/clients/ionoscloud_test.go
@@ -16,6 +16,16 @@ const (
 	expectedUserAgentDbaas   = "crossplane-provider-ionoscloud_ionos-cloud-sdk-go-dbaas-postgres/vv1.0.3"
 )
 
+func setComputeDefaults(cfg *ionos.Configuration) {
+	cfg.HTTPClient = http.DefaultClient
+	cfg.UserAgent = expectedUserAgentCompute
+}
+
+func setDbaaSDefaults(cfg *ionosdbaas.Configuration) {
+	cfg.HTTPClient = http.DefaultClient
+	cfg.UserAgent = expectedUserAgentDbaas
+}
+
 func TestNewIonosClient(t *testing.T) {
 
 	type args struct {
@@ -40,14 +50,12 @@ func TestNewIonosClient(t *testing.T) {
 			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ="}`)},
 			wantComputeConfig: func() *ionos.Configuration {
 				cfg := ionos.NewConfiguration("username", "password", "", "")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentCompute
+				setComputeDefaults(cfg)
 				return cfg
 			}(),
 			wantDbaasConfig: func() *ionosdbaas.Configuration {
 				cfg := ionosdbaas.NewConfiguration("username", "password", "", "")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentDbaas
+				setDbaaSDefaults(cfg)
 				return cfg
 			}(),
 			wantErr: false,
@@ -57,14 +65,12 @@ func TestNewIonosClient(t *testing.T) {
 			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token", "host_url":"https://host"}`)},
 			wantComputeConfig: func() *ionos.Configuration {
 				cfg := ionos.NewConfiguration("username", "password", "token", "https://host")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentCompute
+				setComputeDefaults(cfg)
 				return cfg
 			}(),
 			wantDbaasConfig: func() *ionosdbaas.Configuration {
 				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "https://host")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentDbaas
+				setDbaaSDefaults(cfg)
 				return cfg
 			}(),
 			wantErr: false,
@@ -75,14 +81,12 @@ func TestNewIonosClient(t *testing.T) {
 			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token"}`)},
 			wantComputeConfig: func() *ionos.Configuration {
 				cfg := ionos.NewConfiguration("username", "password", "token", "http://host-from-env")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentCompute
+				setComputeDefaults(cfg)
 				return cfg
 			}(),
 			wantDbaasConfig: func() *ionosdbaas.Configuration {
 				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "http://host-from-env")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentDbaas
+				setDbaaSDefaults(cfg)
 				return cfg
 			}(),
 			wantErr: false,
@@ -93,14 +97,12 @@ func TestNewIonosClient(t *testing.T) {
 			args: args{data: []byte(`{"user": "username","password": "cGFzc3dvcmQ=", "token": "token", "host_url":"https://host"}`)},
 			wantComputeConfig: func() *ionos.Configuration {
 				cfg := ionos.NewConfiguration("username", "password", "token", "https://host")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentCompute
+				setComputeDefaults(cfg)
 				return cfg
 			}(),
 			wantDbaasConfig: func() *ionosdbaas.Configuration {
 				cfg := ionosdbaas.NewConfiguration("username", "password", "token", "https://host")
-				cfg.HTTPClient = http.DefaultClient
-				cfg.UserAgent = expectedUserAgentDbaas
+				setDbaaSDefaults(cfg)
 				return cfg
 			}(),
 			wantErr: false,

--- a/internal/controller/compute/cubeserver/cubeserver.go
+++ b/internal/controller/compute/cubeserver/cubeserver.go
@@ -224,7 +224,7 @@ func (c *externalServer) Update(ctx context.Context, mg resource.Managed) (manag
 	serverID := cr.Status.AtProvider.ServerID
 	instanceInput, err := server.GenerateUpdateCubeServerInput(cr)
 	if err != nil {
-		return managed.ExternalUpdate{}, nil
+		return managed.ExternalUpdate{}, err
 	}
 	_, apiResponse, err := c.service.UpdateServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, serverID, *instanceInput)
 	update := managed.ExternalUpdate{ConnectionDetails: managed.ConnectionDetails{}}
@@ -237,7 +237,7 @@ func (c *externalServer) Update(ctx context.Context, mg resource.Managed) (manag
 	}
 	instanceVolumeInput, err := server.GenerateUpdateVolumeInput(cr)
 	if err != nil {
-		return update, nil
+		return update, err
 	}
 	_, apiResponse, err = c.serviceVolume.UpdateVolume(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Status.AtProvider.VolumeID, *instanceVolumeInput)
 	if err != nil {

--- a/internal/controller/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/controller/dbaas/postgrescluster/postgrescluster.go
@@ -216,7 +216,7 @@ func (c *externalCluster) Update(ctx context.Context, mg resource.Managed) (mana
 	clusterID := cr.Status.AtProvider.ClusterID
 	instanceInput, err := postgrescluster.GenerateUpdateClusterInput(cr)
 	if err != nil {
-		return managed.ExternalUpdate{}, nil
+		return managed.ExternalUpdate{}, err
 	}
 
 	_, apiResponse, err := c.service.UpdateCluster(ctx, clusterID, *instanceInput)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=crossplane-provider-ionoscloud
+sonar.organization=ionos-cloud
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=crossplane-provider-ionoscloud
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION

### Description of your changes

Use the default `IONOS_API_URL` if the creds.HostURL is empty but the variable is set. This allows to overwrite the IONOS API endpoint on a provider level additionally to "per-resource".

So the precedence is:
1. creds.HostURL
2. value of variable IONOS_API_URL set for the provider
3. The default https://api.ionos.com/


This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [x] Run `make reviewable` to ensure this PR is ready for review
- [x] Add or update tests
- [x] Add or update Documentation
- [x] Update CHANGELOG.md (label: `upcoming release`)
- [x] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
