### PR TITLE
fix: check apiResponse on delete

### DIFF
--- a/internal/clients/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/clients/dbaas/postgrescluster/postgrescluster.go
@@ -22,7 +22,7 @@ type ClusterAPIClient struct {
 // ClusterClient is a wrapper around IONOS Service DBaaS Postgres Cluster methods
 type ClusterClient interface {
 	GetCluster(ctx context.Context, clusterID string) (ionoscloud.ClusterResponse, *ionoscloud.APIResponse, error)
-	DeleteCluster(ctx context.Context, clusterID string) error
+	DeleteCluster(ctx context.Context, clusterID string) (*ionoscloud.APIResponse, error)
 	CreateCluster(ctx context.Context, cluster ionoscloud.CreateClusterRequest) (ionoscloud.ClusterResponse, *ionoscloud.APIResponse, error)
 	UpdateCluster(ctx context.Context, clusterID string, cluster ionoscloud.PatchClusterRequest) (ionoscloud.ClusterResponse, *ionoscloud.APIResponse, error)
 }
@@ -33,9 +33,9 @@ func (cp *ClusterAPIClient) GetCluster(ctx context.Context, clusterID string) (i
 }
 
 // DeleteCluster based on clusterID
-func (cp *ClusterAPIClient) DeleteCluster(ctx context.Context, clusterID string) error {
-	_, _, err := cp.DBaaSPostgresClient.ClustersApi.ClustersDelete(ctx, clusterID).Execute()
-	return err
+func (cp *ClusterAPIClient) DeleteCluster(ctx context.Context, clusterID string) (*ionoscloud.APIResponse, error) {
+	_, apiResponse, err := cp.DBaaSPostgresClient.ClustersApi.ClustersDelete(ctx, clusterID).Execute()
+	return apiResponse, err
 }
 
 // CreateCluster based on cluster properties

--- a/internal/controller/compute/cubeserver/cubeserver.go
+++ b/internal/controller/compute/cubeserver/cubeserver.go
@@ -266,7 +266,7 @@ func (c *externalServer) Delete(ctx context.Context, mg resource.Managed) error 
 	apiResponse, err := c.service.DeleteServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Status.AtProvider.ServerID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete cube server. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/compute/datacenter/datacenter.go
+++ b/internal/controller/compute/datacenter/datacenter.go
@@ -236,7 +236,7 @@ func (c *externalDatacenter) Delete(ctx context.Context, mg resource.Managed) er
 	apiResponse, err := c.service.DeleteDatacenter(ctx, cr.Status.AtProvider.DatacenterID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete datacenter. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/compute/firewallrule/firewallrule.go
+++ b/internal/controller/compute/firewallrule/firewallrule.go
@@ -282,7 +282,7 @@ func (c *externalFirewallRule) Delete(ctx context.Context, mg resource.Managed) 
 		cr.Spec.ForProvider.ServerCfg.ServerID, cr.Spec.ForProvider.NicCfg.NicID, cr.Status.AtProvider.FirewallRuleID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete firewallRule. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/compute/ipblock/ipblock.go
+++ b/internal/controller/compute/ipblock/ipblock.go
@@ -239,7 +239,7 @@ func (c *externalIPBlock) Delete(ctx context.Context, mg resource.Managed) error
 	apiResponse, err := c.service.DeleteIPBlock(ctx, cr.Status.AtProvider.IPBlockID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete ipBlock. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/compute/ipfailover/ipfailover.go
+++ b/internal/controller/compute/ipfailover/ipfailover.go
@@ -290,7 +290,7 @@ func (c *externalIPFailover) Delete(ctx context.Context, mg resource.Managed) er
 	_, apiResponse, err := c.service.UpdateLan(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.LanCfg.LanID, *instanceInput)
 	if err != nil {
 		retErr := fmt.Errorf("failed to update lan to remove ipfailover. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return fmt.Errorf("failed to wait for request on removing ipfailover: %w", err)

--- a/internal/controller/compute/lan/lan.go
+++ b/internal/controller/compute/lan/lan.go
@@ -234,7 +234,7 @@ func (c *externalLan) Delete(ctx context.Context, mg resource.Managed) error {
 	apiResponse, err := c.service.DeleteLan(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Status.AtProvider.LanID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete lan. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/compute/nic/nic.go
+++ b/internal/controller/compute/nic/nic.go
@@ -274,7 +274,7 @@ func (c *externalNic) Delete(ctx context.Context, mg resource.Managed) error {
 		cr.Spec.ForProvider.ServerCfg.ServerID, cr.Status.AtProvider.NicID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete nic. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/compute/server/server.go
+++ b/internal/controller/compute/server/server.go
@@ -284,7 +284,7 @@ func (c *externalServer) Delete(ctx context.Context, mg resource.Managed) error 
 	apiResponse, err := c.service.DeleteServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Status.AtProvider.ServerID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete server. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/compute/volume/volume.go
+++ b/internal/controller/compute/volume/volume.go
@@ -239,7 +239,7 @@ func (c *externalVolume) Delete(ctx context.Context, mg resource.Managed) error 
 	apiResponse, err := c.service.DeleteVolume(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Status.AtProvider.VolumeID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete volume. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return err

--- a/internal/controller/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/controller/dbaas/postgrescluster/postgrescluster.go
@@ -241,6 +241,12 @@ func (c *externalCluster) Delete(ctx context.Context, mg resource.Managed) error
 		return nil
 	}
 
-	err := c.service.DeleteCluster(ctx, cr.Status.AtProvider.ClusterID)
-	return errors.Wrap(err, "failed to delete postgres cluster")
+	apiResponse, err := c.service.DeleteCluster(ctx, cr.Status.AtProvider.ClusterID)
+	if err != nil {
+		if apiResponse != nil && apiResponse.Response != nil && apiResponse.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("failed to delete postgres cluster. error: %w", err)
+	}
+	return nil
 }

--- a/internal/controller/k8s/k8scluster/cluster.go
+++ b/internal/controller/k8s/k8scluster/cluster.go
@@ -255,7 +255,7 @@ func (c *externalCluster) Delete(ctx context.Context, mg resource.Managed) error
 	apiResponse, err := c.service.DeleteK8sCluster(ctx, cr.Status.AtProvider.ClusterID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete k8s cluster. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	return nil
 }

--- a/internal/controller/k8s/k8snodepool/nodepool.go
+++ b/internal/controller/k8s/k8snodepool/nodepool.go
@@ -294,7 +294,7 @@ func (c *externalNodePool) Delete(ctx context.Context, mg resource.Managed) erro
 	apiResponse, err = c.service.DeleteK8sNodePool(ctx, cr.Spec.ForProvider.ClusterCfg.ClusterID, cr.Status.AtProvider.NodePoolID)
 	if err != nil {
 		retErr := fmt.Errorf("failed to delete k8s nodepool. error: %w", err)
-		return compute.AddAPIResponseInfo(apiResponse, retErr)
+		return compute.CheckAPIResponseInfo(apiResponse, retErr)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR updates `Delete` functions to check if apiResponse has 404 status code. This way, if the resource was deleted before, deletion is not blocked.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [x] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation (if applicable)
- [ ] Update CHANGELOG.md (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
