### PR TITLE
feat: add unique names support for IONOS Cloud resources

### DIFF
--- a/apis/compute/v1alpha1/server_types.go
+++ b/apis/compute/v1alpha1/server_types.go
@@ -57,6 +57,7 @@ type ServerParameters struct {
 	// CPU architecture on which server gets provisioned; not all CPU architectures are available in all datacenter regions;
 	// available CPU architectures can be retrieved from the datacenter resource.
 	//
+	// +immutable
 	// +kubebuilder:validation:Enum=AMD_OPTERON;INTEL_SKYLAKE;INTEL_XEON
 	CPUFamily string `json:"cpuFamily,omitempty"`
 	// +kubebuilder:validation:Optional

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -35,6 +35,7 @@ func main() {
 	var (
 		app               = kingpin.New(filepath.Base(os.Args[0]), "IONOS Cloud support for Crossplane.").DefaultEnvars()
 		debug             = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		uniqueNames       = app.Flag("unique-names", "Enable uniqueness name support for IONOS Cloud resources").Short('u').Bool()
 		syncInterval      = app.Flag("sync", "Controller manager sync interval such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
 		pollInterval      = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for changes.").Default("1m").Duration()
 		leaderElection    = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
@@ -66,6 +67,6 @@ func main() {
 
 	rl := ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add IONOS Cloud APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log, rl, *pollInterval, *createGracePeriod, *timeout), "Cannot setup IONOS Cloud controllers")
+	kingpin.FatalIfError(controller.Setup(mgr, log, rl, *pollInterval, *createGracePeriod, *timeout, *uniqueNames), "Cannot setup IONOS Cloud controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/controller"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 func main() {
@@ -67,6 +68,7 @@ func main() {
 
 	rl := ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add IONOS Cloud APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log, rl, *pollInterval, *createGracePeriod, *timeout, *uniqueNames), "Cannot setup IONOS Cloud controllers")
+	options := utils.NewConfigurationOptions(*pollInterval, *createGracePeriod, *timeout, *uniqueNames)
+	kingpin.FatalIfError(controller.Setup(mgr, log, rl, options), "Cannot setup IONOS Cloud controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -276,6 +276,40 @@ More details about Composite Resources can be found here:
 - [Composite Resources Concept](https://crossplane.io/docs/v1.7/concepts/composition.html)
 - [Composite Resources Reference](https://crossplane.io/docs/v1.7/reference/composition.html)
 
+## Name Uniqueness Support for IONOS Cloud Resources
+
+The Crossplane Provider IONOS Cloud has support for `--unique-names` flag, in order to enable name uniqueness support
+for IONOS Cloud Resources.
+
+You can create a `ControllerConfig`:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1alpha1
+kind: ControllerConfig
+metadata:
+  name: provider-config
+spec:
+  args:
+    - --unique-names
+EOF
+```
+
+And reference it from the `Provider`:
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-ionos
+spec:
+  package: ghcr.io/ionos-cloud/crossplane-provider-ionoscloud:latest
+  controllerConfigRef:
+    name: provider-config
+EOF
+```
+
 ## Debug Mode
 
 ### Provider Logs

--- a/docs/README.md
+++ b/docs/README.md
@@ -279,7 +279,14 @@ More details about Composite Resources can be found here:
 ## Name Uniqueness Support for IONOS Cloud Resources
 
 The Crossplane Provider IONOS Cloud has support for `--unique-names` flag, in order to enable name uniqueness support
-for IONOS Cloud Resources.
+for IONOS Cloud Resources. If the `--unique-names` option is set, the Crossplane Provider for IONOS Cloud will check if
+a resource with the same name already exists. If multiple resources with the specified name are found, an error is
+thrown. If a single resource with the specified name is found, Crossplane Provider will perform an extra step and check
+if the immutable parameters are as expected. If the resource has the specified name, but different immutable parameters,
+an error is thrown. If no resource with the specified name is found, a new resource will be created.
+
+_Note_: Resources will have unique names at their level, e.g. k8s clusters will have unique name per account, k8s node
+pools will have unique name per k8s cluster.
 
 You can create a `ControllerConfig`:
 

--- a/examples/provider/debug-config.yaml
+++ b/examples/provider/debug-config.yaml
@@ -5,3 +5,5 @@ metadata:
 spec:
   args:
     - --debug
+    # In order to enable name uniqueness support for IONOS Cloud Resources, uncomment the next line:
+    # - --unique-names

--- a/internal/clients/alb/applicationloadbalancer/applicationloadbalancer.go
+++ b/internal/clients/alb/applicationloadbalancer/applicationloadbalancer.go
@@ -31,12 +31,12 @@ type Client interface {
 
 // CheckDuplicateApplicationLoadBalancer based on datacenterID, applicationloadbalancerName
 func (cp *APIClient) CheckDuplicateApplicationLoadBalancer(ctx context.Context, datacenterID, applicationloadbalancerName string) (*sdkgo.ApplicationLoadBalancer, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.ApplicationLoadBalancersApi.DatacentersApplicationloadbalancersGet(ctx, datacenterID).Depth(utils.DepthQueryParam).Execute()
+	applicationLoadBalancers, _, err := cp.ComputeClient.ApplicationLoadBalancersApi.DatacentersApplicationloadbalancersGet(ctx, datacenterID).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.ApplicationLoadBalancer, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := applicationLoadBalancers.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/alb/applicationloadbalancer/applicationloadbalancer.go
+++ b/internal/clients/alb/applicationloadbalancer/applicationloadbalancer.go
@@ -2,6 +2,7 @@ package applicationloadbalancer
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	sdkgo "github.com/ionos-cloud/sdk-go/v6"
@@ -19,11 +20,51 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service ApplicationLoadBalancer methods
 type Client interface {
+	CheckDuplicateApplicationLoadBalancer(ctx context.Context, datacenterID, applicationloadbalancerName string) (*sdkgo.ApplicationLoadBalancer, error)
+	GetApplicationLoadBalancerID(applicationloadbalancer *sdkgo.ApplicationLoadBalancer) (string, error)
 	GetApplicationLoadBalancer(ctx context.Context, datacenterID, applicationloadbalancerID string) (sdkgo.ApplicationLoadBalancer, *sdkgo.APIResponse, error)
 	CreateApplicationLoadBalancer(ctx context.Context, datacenterID string, applicationloadbalancer sdkgo.ApplicationLoadBalancer) (sdkgo.ApplicationLoadBalancer, *sdkgo.APIResponse, error)
 	UpdateApplicationLoadBalancer(ctx context.Context, datacenterID, applicationloadbalancerID string, applicationloadbalancer sdkgo.ApplicationLoadBalancerProperties) (sdkgo.ApplicationLoadBalancer, *sdkgo.APIResponse, error)
 	DeleteApplicationLoadBalancer(ctx context.Context, datacenterID, applicationloadbalancerID string) (*sdkgo.APIResponse, error)
 	GetAPIClient() *sdkgo.APIClient
+}
+
+// CheckDuplicateApplicationLoadBalancer based on datacenterID, applicationloadbalancerName
+func (cp *APIClient) CheckDuplicateApplicationLoadBalancer(ctx context.Context, datacenterID, applicationloadbalancerName string) (*sdkgo.ApplicationLoadBalancer, error) { // nolint: gocyclo
+	datacenters, _, err := cp.ComputeClient.ApplicationLoadBalancersApi.DatacentersApplicationloadbalancersGet(ctx, datacenterID).Depth(utils.DepthQueryParam).Execute()
+	if err != nil {
+		return nil, err
+	}
+	matchedItems := make([]sdkgo.ApplicationLoadBalancer, 0)
+	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+		for _, item := range *itemsOk {
+			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
+				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
+					if *nameOk == applicationloadbalancerName {
+						matchedItems = append(matchedItems, item)
+					}
+				}
+			}
+		}
+	}
+	if len(matchedItems) == 0 {
+		return nil, nil
+	}
+	if len(matchedItems) > 1 {
+		return nil, fmt.Errorf("error: found multiple applicationloadbalancers with the name %v", applicationloadbalancerName)
+	}
+	return &matchedItems[0], nil
+}
+
+// GetApplicationLoadBalancerID based on applicationloadbalancer
+func (cp *APIClient) GetApplicationLoadBalancerID(applicationloadbalancer *sdkgo.ApplicationLoadBalancer) (string, error) {
+	if applicationloadbalancer != nil {
+		if idOk, ok := applicationloadbalancer.GetIdOk(); ok && idOk != nil {
+			return *idOk, nil
+		}
+		return "", fmt.Errorf("error: getting applicationloadbalancer id")
+	}
+	return "", nil
 }
 
 // GetApplicationLoadBalancer based on applicationloadbalancerID

--- a/internal/clients/alb/forwardingrule/forwardingrule.go
+++ b/internal/clients/alb/forwardingrule/forwardingrule.go
@@ -30,12 +30,12 @@ type Client interface {
 
 // CheckDuplicateForwardingRule based on datacenterID, applicationloadbalancerName
 func (cp *APIClient) CheckDuplicateForwardingRule(ctx context.Context, datacenterID, applicationloadbalancerID, forwardingruleName string) (*sdkgo.ApplicationLoadBalancerForwardingRule, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.ApplicationLoadBalancersApi.DatacentersApplicationloadbalancersForwardingrulesGet(ctx, datacenterID, applicationloadbalancerID).Depth(utils.DepthQueryParam).Execute()
+	forwardingRules, _, err := cp.ComputeClient.ApplicationLoadBalancersApi.DatacentersApplicationloadbalancersForwardingrulesGet(ctx, datacenterID, applicationloadbalancerID).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.ApplicationLoadBalancerForwardingRule, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := forwardingRules.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/alb/targetgroup/targetgroup.go
+++ b/internal/clients/alb/targetgroup/targetgroup.go
@@ -30,12 +30,12 @@ type Client interface {
 
 // CheckDuplicateTargetGroup based on targetGroupName
 func (cp *APIClient) CheckDuplicateTargetGroup(ctx context.Context, targetGroupName string) (*sdkgo.TargetGroup, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.TargetGroupsApi.TargetgroupsGet(ctx).Depth(utils.DepthQueryParam).Execute()
+	targetGroups, _, err := cp.ComputeClient.TargetGroupsApi.TargetgroupsGet(ctx).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.TargetGroup, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := targetGroups.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/backup/backupunit/backupunit.go
+++ b/internal/clients/backup/backupunit/backupunit.go
@@ -18,6 +18,8 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service BackupUnit methods
 type Client interface {
+	CheckDuplicateBackupUnit(ctx context.Context, backupUnitName string) (*sdkgo.BackupUnit, error)
+	GetBackupUnitID(backupUnit *sdkgo.BackupUnit) (string, error)
 	GetBackupUnit(ctx context.Context, backupUnitID string) (sdkgo.BackupUnit, *sdkgo.APIResponse, error)
 	GetBackupUnits(ctx context.Context) (sdkgo.BackupUnits, *sdkgo.APIResponse, error)
 	GetBackupUnitIDByName(ctx context.Context, backupUnitName string) (string, error)
@@ -25,6 +27,44 @@ type Client interface {
 	UpdateBackupUnit(ctx context.Context, backupUnitID string, backupUnit sdkgo.BackupUnitProperties) (sdkgo.BackupUnit, *sdkgo.APIResponse, error)
 	DeleteBackupUnit(ctx context.Context, backupUnitID string) (*sdkgo.APIResponse, error)
 	GetAPIClient() *sdkgo.APIClient
+}
+
+// CheckDuplicateBackupUnit based on backupUnitName
+func (cp *APIClient) CheckDuplicateBackupUnit(ctx context.Context, backupUnitName string) (*sdkgo.BackupUnit, error) { // nolint: gocyclo
+	datacenters, _, err := cp.ComputeClient.BackupUnitsApi.BackupunitsGet(ctx).Depth(utils.DepthQueryParam).Execute()
+	if err != nil {
+		return nil, err
+	}
+	matchedItems := make([]sdkgo.BackupUnit, 0)
+	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+		for _, item := range *itemsOk {
+			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
+				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
+					if *nameOk == backupUnitName {
+						matchedItems = append(matchedItems, item)
+					}
+				}
+			}
+		}
+	}
+	if len(matchedItems) == 0 {
+		return nil, nil
+	}
+	if len(matchedItems) > 1 {
+		return nil, fmt.Errorf("error: found multiple backup units with the name %v", backupUnitName)
+	}
+	return &matchedItems[0], nil
+}
+
+// GetBackupUnitID based on backupUnit
+func (cp *APIClient) GetBackupUnitID(backupUnit *sdkgo.BackupUnit) (string, error) {
+	if backupUnit != nil {
+		if idOk, ok := backupUnit.GetIdOk(); ok && idOk != nil {
+			return *idOk, nil
+		}
+		return "", fmt.Errorf("error: getting backup unit id")
+	}
+	return "", nil
 }
 
 // GetBackupUnit based on backupUnitID

--- a/internal/clients/backup/backupunit/backupunit.go
+++ b/internal/clients/backup/backupunit/backupunit.go
@@ -31,12 +31,12 @@ type Client interface {
 
 // CheckDuplicateBackupUnit based on backupUnitName
 func (cp *APIClient) CheckDuplicateBackupUnit(ctx context.Context, backupUnitName string) (*sdkgo.BackupUnit, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.BackupUnitsApi.BackupunitsGet(ctx).Depth(utils.DepthQueryParam).Execute()
+	backupUnits, _, err := cp.ComputeClient.BackupUnitsApi.BackupunitsGet(ctx).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.BackupUnit, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := backupUnits.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/compute/datacenter/datacenter.go
+++ b/internal/clients/compute/datacenter/datacenter.go
@@ -18,7 +18,7 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service Datacenter methods
 type Client interface {
-	CheckDuplicateDatacenter(ctx context.Context, datacenterName, loacation string) (*sdkgo.Datacenter, error)
+	CheckDuplicateDatacenter(ctx context.Context, datacenterName, location string) (*sdkgo.Datacenter, error)
 	GetDatacenterID(datacenter *sdkgo.Datacenter) (string, error)
 	GetDatacenter(ctx context.Context, datacenterID string) (sdkgo.Datacenter, *sdkgo.APIResponse, error)
 	CreateDatacenter(ctx context.Context, datacenter sdkgo.Datacenter) (sdkgo.Datacenter, *sdkgo.APIResponse, error)

--- a/internal/clients/compute/datacenter/datacenter.go
+++ b/internal/clients/compute/datacenter/datacenter.go
@@ -2,6 +2,7 @@ package datacenter
 
 import (
 	"context"
+	"fmt"
 
 	sdkgo "github.com/ionos-cloud/sdk-go/v6"
 
@@ -17,12 +18,59 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service Datacenter methods
 type Client interface {
+	CheckDuplicateDatacenter(ctx context.Context, datacenterName, loacation string) (*sdkgo.Datacenter, error)
+	GetDatacenterID(datacenter *sdkgo.Datacenter) (string, error)
 	GetDatacenter(ctx context.Context, datacenterID string) (sdkgo.Datacenter, *sdkgo.APIResponse, error)
 	CreateDatacenter(ctx context.Context, datacenter sdkgo.Datacenter) (sdkgo.Datacenter, *sdkgo.APIResponse, error)
 	UpdateDatacenter(ctx context.Context, datacenterID string, datacenter sdkgo.DatacenterProperties) (sdkgo.Datacenter, *sdkgo.APIResponse, error)
 	DeleteDatacenter(ctx context.Context, datacenterID string) (*sdkgo.APIResponse, error)
 	GetCPUFamiliesForDatacenter(ctx context.Context, datacenterID string) ([]string, error)
 	GetAPIClient() *sdkgo.APIClient
+}
+
+// CheckDuplicateDatacenter based on datacenterName, and the immutable property location
+func (cp *APIClient) CheckDuplicateDatacenter(ctx context.Context, datacenterName, location string) (*sdkgo.Datacenter, error) { // nolint: gocyclo
+	datacenters, _, err := cp.ComputeClient.DataCentersApi.DatacentersGet(ctx).Depth(utils.DepthQueryParam).Execute()
+	if err != nil {
+		return nil, err
+	}
+	matchedItems := make([]sdkgo.Datacenter, 0)
+	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+		for _, item := range *itemsOk {
+			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
+				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
+					if *nameOk == datacenterName {
+						// After checking the name, check the immutable properties
+						if locationOk, ok := propertiesOk.GetLocationOk(); ok && locationOk != nil {
+							if *locationOk == location {
+								matchedItems = append(matchedItems, item)
+							} else {
+								return nil, fmt.Errorf("error: found datacenter with the same name, but different immutable property location")
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(matchedItems) == 0 {
+		return nil, nil
+	}
+	if len(matchedItems) > 1 {
+		return nil, fmt.Errorf("error: found multiple datacenters with the same name")
+	}
+	return &matchedItems[0], nil
+}
+
+// GetDatacenterID based on datacenter
+func (cp *APIClient) GetDatacenterID(datacenter *sdkgo.Datacenter) (string, error) {
+	if datacenter != nil {
+		if idOk, ok := datacenter.GetIdOk(); ok && idOk != nil {
+			return *idOk, nil
+		}
+		return "", fmt.Errorf("error: getting datacenter id")
+	}
+	return "", nil
 }
 
 // GetDatacenter based on datacenterID

--- a/internal/clients/compute/datacenter/datacenter.go
+++ b/internal/clients/compute/datacenter/datacenter.go
@@ -45,7 +45,7 @@ func (cp *APIClient) CheckDuplicateDatacenter(ctx context.Context, datacenterNam
 							if *locationOk == location {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found datacenter with the same name, but different immutable property location")
+								return nil, fmt.Errorf("error: found datacenter with the name %v, but immutable property location %v", datacenterName, *locationOk)
 							}
 						}
 					}
@@ -57,7 +57,7 @@ func (cp *APIClient) CheckDuplicateDatacenter(ctx context.Context, datacenterNam
 		return nil, nil
 	}
 	if len(matchedItems) > 1 {
-		return nil, fmt.Errorf("error: found multiple datacenters with the same name")
+		return nil, fmt.Errorf("error: found multiple datacenters with the name %v", datacenterName)
 	}
 	return &matchedItems[0], nil
 }

--- a/internal/clients/compute/datacenter/datacenter.go
+++ b/internal/clients/compute/datacenter/datacenter.go
@@ -42,12 +42,11 @@ func (cp *APIClient) CheckDuplicateDatacenter(ctx context.Context, datacenterNam
 					if *nameOk == datacenterName {
 						// After checking the name, check the immutable properties
 						if locationOk, ok := propertiesOk.GetLocationOk(); ok && locationOk != nil {
-							if *locationOk == location {
-								matchedItems = append(matchedItems, item)
-							} else {
+							if *locationOk != location {
 								return nil, fmt.Errorf("error: found datacenter with the name %v, but immutable property location different. expected: %v actual: %v", datacenterName, location, *locationOk)
 							}
 						}
+						matchedItems = append(matchedItems, item)
 					}
 				}
 			}

--- a/internal/clients/compute/datacenter/datacenter.go
+++ b/internal/clients/compute/datacenter/datacenter.go
@@ -45,7 +45,7 @@ func (cp *APIClient) CheckDuplicateDatacenter(ctx context.Context, datacenterNam
 							if *locationOk == location {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found datacenter with the name %v, but immutable property location %v", datacenterName, *locationOk)
+								return nil, fmt.Errorf("error: found datacenter with the name %v, but immutable property location different. expected: %v actual: %v", datacenterName, location, *locationOk)
 							}
 						}
 					}

--- a/internal/clients/compute/firewallrule/firewallrule.go
+++ b/internal/clients/compute/firewallrule/firewallrule.go
@@ -30,12 +30,12 @@ type Client interface {
 
 // CheckDuplicateFirewallRule based on firewallRuleName, and the immutable property protocol
 func (cp *APIClient) CheckDuplicateFirewallRule(ctx context.Context, datacenterID, serverID, nicID, firewallRuleName, protocol string) (*sdkgo.FirewallRule, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.FirewallRulesApi.DatacentersServersNicsFirewallrulesGet(ctx, datacenterID, serverID, nicID).Depth(utils.DepthQueryParam).Execute()
+	firewallRules, _, err := cp.ComputeClient.FirewallRulesApi.DatacentersServersNicsFirewallrulesGet(ctx, datacenterID, serverID, nicID).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.FirewallRule, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := firewallRules.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/compute/firewallrule/firewallrule.go
+++ b/internal/clients/compute/firewallrule/firewallrule.go
@@ -45,7 +45,7 @@ func (cp *APIClient) CheckDuplicateFirewallRule(ctx context.Context, datacenterI
 							if *protocolOk == protocol {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found firewall rule with the name %v, but immutable property protocol %v", firewallRuleName, *protocolOk)
+								return nil, fmt.Errorf("error: found firewall rule with the name %v, but immutable property protocol different. expected: %v actual: %v", firewallRuleName, protocol, *protocolOk)
 							}
 						}
 					}

--- a/internal/clients/compute/firewallrule/firewallrule.go
+++ b/internal/clients/compute/firewallrule/firewallrule.go
@@ -42,12 +42,11 @@ func (cp *APIClient) CheckDuplicateFirewallRule(ctx context.Context, datacenterI
 					if *nameOk == firewallRuleName {
 						// After checking the name, check the immutable properties
 						if protocolOk, ok := propertiesOk.GetProtocolOk(); ok && protocolOk != nil {
-							if *protocolOk == protocol {
-								matchedItems = append(matchedItems, item)
-							} else {
+							if *protocolOk != protocol {
 								return nil, fmt.Errorf("error: found firewall rule with the name %v, but immutable property protocol different. expected: %v actual: %v", firewallRuleName, protocol, *protocolOk)
 							}
 						}
+						matchedItems = append(matchedItems, item)
 					}
 				}
 			}

--- a/internal/clients/compute/ipblock/ipblock.go
+++ b/internal/clients/compute/ipblock/ipblock.go
@@ -31,12 +31,12 @@ type Client interface {
 
 // CheckDuplicateIPBlock based on ipBlockName, and the immutable property location
 func (cp *APIClient) CheckDuplicateIPBlock(ctx context.Context, ipBlockName, location string) (*sdkgo.IpBlock, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.IPBlocksApi.IpblocksGet(ctx).Depth(utils.DepthQueryParam).Execute()
+	ipBlocks, _, err := cp.ComputeClient.IPBlocksApi.IpblocksGet(ctx).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.IpBlock, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := ipBlocks.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/compute/ipblock/ipblock.go
+++ b/internal/clients/compute/ipblock/ipblock.go
@@ -46,7 +46,7 @@ func (cp *APIClient) CheckDuplicateIPBlock(ctx context.Context, ipBlockName, loc
 							if *locationOk == location {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found ipblock with the name %v, but immutable property location %v", ipBlockName, *locationOk)
+								return nil, fmt.Errorf("error: found ipblock with the name %v, but immutable property location different. expected: %v actual: %v", ipBlockName, location, *locationOk)
 							}
 						}
 					}

--- a/internal/clients/compute/ipblock/ipblock.go
+++ b/internal/clients/compute/ipblock/ipblock.go
@@ -43,12 +43,11 @@ func (cp *APIClient) CheckDuplicateIPBlock(ctx context.Context, ipBlockName, loc
 					if *nameOk == ipBlockName {
 						// After checking the name, check the immutable properties
 						if locationOk, ok := propertiesOk.GetLocationOk(); ok && locationOk != nil {
-							if *locationOk == location {
-								matchedItems = append(matchedItems, item)
-							} else {
+							if *locationOk != location {
 								return nil, fmt.Errorf("error: found ipblock with the name %v, but immutable property location different. expected: %v actual: %v", ipBlockName, location, *locationOk)
 							}
 						}
+						matchedItems = append(matchedItems, item)
 					}
 				}
 			}

--- a/internal/clients/compute/lan/lan.go
+++ b/internal/clients/compute/lan/lan.go
@@ -19,12 +19,52 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service Lan methods
 type Client interface {
+	CheckDuplicateLan(ctx context.Context, datacenterID, lanName string) (*sdkgo.Lan, error)
+	GetLanID(lan *sdkgo.Lan) (string, error)
 	GetLan(ctx context.Context, datacenterID, lanID string) (sdkgo.Lan, *sdkgo.APIResponse, error)
 	GetLanIPFailovers(ctx context.Context, datacenterID, lanID string) ([]sdkgo.IPFailover, error)
 	CreateLan(ctx context.Context, datacenterID string, lan sdkgo.LanPost) (sdkgo.LanPost, *sdkgo.APIResponse, error)
 	UpdateLan(ctx context.Context, datacenterID, lanID string, lan sdkgo.LanProperties) (sdkgo.Lan, *sdkgo.APIResponse, error)
 	DeleteLan(ctx context.Context, datacenterID, lanID string) (*sdkgo.APIResponse, error)
 	GetAPIClient() *sdkgo.APIClient
+}
+
+// CheckDuplicateLan based on datacenterID, lanName
+func (cp *APIClient) CheckDuplicateLan(ctx context.Context, datacenterID, lanName string) (*sdkgo.Lan, error) { // nolint: gocyclo
+	datacenters, _, err := cp.ComputeClient.LANsApi.DatacentersLansGet(ctx, datacenterID).Depth(utils.DepthQueryParam).Execute()
+	if err != nil {
+		return nil, err
+	}
+	matchedItems := make([]sdkgo.Lan, 0)
+	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+		for _, item := range *itemsOk {
+			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
+				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
+					if *nameOk == lanName {
+						matchedItems = append(matchedItems, item)
+					}
+				}
+			}
+		}
+	}
+	if len(matchedItems) == 0 {
+		return nil, nil
+	}
+	if len(matchedItems) > 1 {
+		return nil, fmt.Errorf("error: found multiple lans with the name %v", lanName)
+	}
+	return &matchedItems[0], nil
+}
+
+// GetLanID based on lan
+func (cp *APIClient) GetLanID(lan *sdkgo.Lan) (string, error) {
+	if lan != nil {
+		if idOk, ok := lan.GetIdOk(); ok && idOk != nil {
+			return *idOk, nil
+		}
+		return "", fmt.Errorf("error: getting lan id")
+	}
+	return "", nil
 }
 
 // GetLan based on datacenterID, lanID

--- a/internal/clients/compute/lan/lan.go
+++ b/internal/clients/compute/lan/lan.go
@@ -31,12 +31,12 @@ type Client interface {
 
 // CheckDuplicateLan based on datacenterID, lanName
 func (cp *APIClient) CheckDuplicateLan(ctx context.Context, datacenterID, lanName string) (*sdkgo.Lan, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.LANsApi.DatacentersLansGet(ctx, datacenterID).Depth(utils.DepthQueryParam).Execute()
+	lans, _, err := cp.ComputeClient.LANsApi.DatacentersLansGet(ctx, datacenterID).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.Lan, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := lans.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/compute/nic/nic.go
+++ b/internal/clients/compute/nic/nic.go
@@ -2,6 +2,7 @@ package nic
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"github.com/rung/go-safecast"
@@ -20,11 +21,51 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service Nic methods
 type Client interface {
+	CheckDuplicateNic(ctx context.Context, datacenterID, serverID, nicName string) (*sdkgo.Nic, error)
+	GetNicID(nic *sdkgo.Nic) (string, error)
 	GetNic(ctx context.Context, datacenterID, serverID, nicID string) (sdkgo.Nic, *sdkgo.APIResponse, error)
 	CreateNic(ctx context.Context, datacenterID, serverID string, nic sdkgo.Nic) (sdkgo.Nic, *sdkgo.APIResponse, error)
 	UpdateNic(ctx context.Context, datacenterID, serverID, nicID string, nicProperties sdkgo.NicProperties) (sdkgo.Nic, *sdkgo.APIResponse, error)
 	DeleteNic(ctx context.Context, datacenterID, serverID, nicID string) (*sdkgo.APIResponse, error)
 	GetAPIClient() *sdkgo.APIClient
+}
+
+// CheckDuplicateNic based on datacenterID, serverID, nicName and the immutable property location
+func (cp *APIClient) CheckDuplicateNic(ctx context.Context, datacenterID, serverID, nicName string) (*sdkgo.Nic, error) { // nolint: gocyclo
+	datacenters, _, err := cp.ComputeClient.NetworkInterfacesApi.DatacentersServersNicsGet(ctx, datacenterID, serverID).Depth(utils.DepthQueryParam).Execute()
+	if err != nil {
+		return nil, err
+	}
+	matchedItems := make([]sdkgo.Nic, 0)
+	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+		for _, item := range *itemsOk {
+			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
+				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
+					if *nameOk == nicName {
+						matchedItems = append(matchedItems, item)
+					}
+				}
+			}
+		}
+	}
+	if len(matchedItems) == 0 {
+		return nil, nil
+	}
+	if len(matchedItems) > 1 {
+		return nil, fmt.Errorf("error: found multiple nics with the name %v", nicName)
+	}
+	return &matchedItems[0], nil
+}
+
+// GetNicID based on nic
+func (cp *APIClient) GetNicID(nic *sdkgo.Nic) (string, error) {
+	if nic != nil {
+		if idOk, ok := nic.GetIdOk(); ok && idOk != nil {
+			return *idOk, nil
+		}
+		return "", fmt.Errorf("error: getting nic id")
+	}
+	return "", nil
 }
 
 // GetNic based on datacenterID, serverID, nicID

--- a/internal/clients/compute/nic/nic.go
+++ b/internal/clients/compute/nic/nic.go
@@ -32,12 +32,12 @@ type Client interface {
 
 // CheckDuplicateNic based on datacenterID, serverID, nicName and the immutable property location
 func (cp *APIClient) CheckDuplicateNic(ctx context.Context, datacenterID, serverID, nicName string) (*sdkgo.Nic, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.NetworkInterfacesApi.DatacentersServersNicsGet(ctx, datacenterID, serverID).Depth(utils.DepthQueryParam).Execute()
+	nics, _, err := cp.ComputeClient.NetworkInterfacesApi.DatacentersServersNicsGet(ctx, datacenterID, serverID).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.Nic, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := nics.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/compute/server/server.go
+++ b/internal/clients/compute/server/server.go
@@ -51,7 +51,7 @@ func (cp *APIClient) CheckDuplicateServer(ctx context.Context, datacenterID, ser
 							if cpuFamily == "" || cpuFamily == *cpuFamilyOk {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found server with the name %v, but immutable property cpuFamily %v", serverName, *cpuFamilyOk)
+								return nil, fmt.Errorf("error: found server with the name %v, but immutable property cpuFamily. expected: %v actual: %v", serverName, cpuFamily, *cpuFamilyOk)
 							}
 						}
 					}

--- a/internal/clients/compute/server/server.go
+++ b/internal/clients/compute/server/server.go
@@ -44,11 +44,6 @@ func (cp *APIClient) CheckDuplicateServer(ctx context.Context, datacenterID, ser
 	if itemsOk, ok := servers.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
-				if typeOk, ok := propertiesOk.GetTypeOk(); ok && typeOk != nil {
-					if *typeOk == serverCubeType {
-						continue
-					}
-				}
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
 					if *nameOk == serverName {
 						// After checking the name, check the immutable properties

--- a/internal/clients/compute/server/server.go
+++ b/internal/clients/compute/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	sdkgo "github.com/ionos-cloud/sdk-go/v6"
@@ -20,6 +21,7 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service Server methods
 type Client interface {
+	CheckDuplicateServer(ctx context.Context, datacenterID, serverName, cpuFamily string) (*sdkgo.Server, error)
 	GetServer(ctx context.Context, datacenterID, serverID string) (sdkgo.Server, *sdkgo.APIResponse, error)
 	CreateServer(ctx context.Context, datacenterID string, server sdkgo.Server) (sdkgo.Server, *sdkgo.APIResponse, error)
 	UpdateServer(ctx context.Context, datacenterID, serverID string, server sdkgo.ServerProperties) (sdkgo.Server, *sdkgo.APIResponse, error)
@@ -29,6 +31,57 @@ type Client interface {
 	AttachCdrom(ctx context.Context, datacenterID, serverID string, cdrom sdkgo.Image) (sdkgo.Image, *sdkgo.APIResponse, error)
 	DetachCdrom(ctx context.Context, datacenterID, serverID, imageID string) (*sdkgo.APIResponse, error)
 	GetAPIClient() *sdkgo.APIClient
+	GetServerID(server *sdkgo.Server) (string, error)
+}
+
+// CheckDuplicateServer based on serverName, and the immutable property location
+func (cp *APIClient) CheckDuplicateServer(ctx context.Context, datacenterID, serverName, cpuFamily string) (*sdkgo.Server, error) { // nolint: gocyclo
+	servers, _, err := cp.ComputeClient.ServersApi.DatacentersServersGet(ctx, datacenterID).Depth(utils.DepthQueryParam).Execute()
+	if err != nil {
+		return nil, err
+	}
+	matchedItems := make([]sdkgo.Server, 0)
+	if itemsOk, ok := servers.GetItemsOk(); ok && itemsOk != nil {
+		for _, item := range *itemsOk {
+			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
+				if typeOk, ok := propertiesOk.GetTypeOk(); ok && typeOk != nil {
+					if *typeOk == serverCubeType {
+						continue
+					}
+				}
+				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
+					if *nameOk == serverName {
+						// After checking the name, check the immutable properties
+						if cpuFamilyOk, ok := propertiesOk.GetCpuFamilyOk(); ok && cpuFamilyOk != nil {
+							if cpuFamily == "" || cpuFamily == *cpuFamilyOk {
+								matchedItems = append(matchedItems, item)
+							} else {
+								return nil, fmt.Errorf("error: found server with the same name, but different immutable property cpuFamily")
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(matchedItems) == 0 {
+		return nil, nil
+	}
+	if len(matchedItems) > 1 {
+		return nil, fmt.Errorf("error: found multiple servers with the same name")
+	}
+	return &matchedItems[0], nil
+}
+
+// GetServerID based on datacenter
+func (cp *APIClient) GetServerID(server *sdkgo.Server) (string, error) {
+	if server != nil {
+		if idOk, ok := server.GetIdOk(); ok && idOk != nil {
+			return *idOk, nil
+		}
+		return "", fmt.Errorf("error: getting server id")
+	}
+	return "", nil
 }
 
 // GetServer based on datacenterID and serverID

--- a/internal/clients/compute/server/server.go
+++ b/internal/clients/compute/server/server.go
@@ -56,7 +56,7 @@ func (cp *APIClient) CheckDuplicateServer(ctx context.Context, datacenterID, ser
 							if cpuFamily == "" || cpuFamily == *cpuFamilyOk {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found server with the same name, but different immutable property cpuFamily")
+								return nil, fmt.Errorf("error: found server with the name %v, but immutable property cpuFamily %v", serverName, *cpuFamilyOk)
 							}
 						}
 					}
@@ -68,7 +68,7 @@ func (cp *APIClient) CheckDuplicateServer(ctx context.Context, datacenterID, ser
 		return nil, nil
 	}
 	if len(matchedItems) > 1 {
-		return nil, fmt.Errorf("error: found multiple servers with the same name")
+		return nil, fmt.Errorf("error: found multiple servers with the name %v", serverName)
 	}
 	return &matchedItems[0], nil
 }

--- a/internal/clients/compute/server/server.go
+++ b/internal/clients/compute/server/server.go
@@ -51,7 +51,7 @@ func (cp *APIClient) CheckDuplicateServer(ctx context.Context, datacenterID, ser
 							if cpuFamily == "" || cpuFamily == *cpuFamilyOk {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found server with the name %v, but immutable property cpuFamily. expected: %v actual: %v", serverName, cpuFamily, *cpuFamilyOk)
+								return nil, fmt.Errorf("error: found server with the name %v, but immutable property cpuFamily different. expected: %v actual: %v", serverName, cpuFamily, *cpuFamilyOk)
 							}
 						}
 					}

--- a/internal/clients/compute/volume/volume.go
+++ b/internal/clients/compute/volume/volume.go
@@ -48,15 +48,15 @@ func (cp *APIClient) CheckDuplicateVolume(ctx context.Context, datacenterID, vol
 						}
 						if availabilityZoneOk, ok := propertiesOk.GetAvailabilityZoneOk(); ok && availabilityZoneOk != nil {
 							if *availabilityZoneOk != availabilityZone {
-								return nil, fmt.Errorf("error: found volume with the name %v, but immutable property availability zone different. expected: %v actual: %v", volumeName, availabilityZone, *availabilityZoneOk)
+								return nil, fmt.Errorf("error: found volume with the name %v, but immutable property availabilityZone different. expected: %v actual: %v", volumeName, availabilityZone, *availabilityZoneOk)
 							}
 						}
-						if licenceTypeOk, ok := propertiesOk.GetLicenceTypeOk(); ok && licenceTypeOk != nil {
+						if licenceTypeOk, ok := propertiesOk.GetLicenceTypeOk(); ok && licenceTypeOk != nil && licenceType != "" {
 							if *licenceTypeOk != licenceType {
-								return nil, fmt.Errorf("error: found volume with the name %v, but immutable property licence type different. expected: %v actual: %v", volumeName, licenceType, *licenceTypeOk)
+								return nil, fmt.Errorf("error: found volume with the name %v, but immutable property licenceType different. expected: %v actual: %v", volumeName, licenceType, *licenceTypeOk)
 							}
 						}
-						if imageOk, ok := propertiesOk.GetImageOk(); ok && imageOk != nil {
+						if imageOk, ok := propertiesOk.GetImageOk(); ok && imageOk != nil && image != "" {
 							if *imageOk != image {
 								return nil, fmt.Errorf("error: found volume with the name %v, but immutable property image different. expected: %v actual: %v", volumeName, image, *imageOk)
 							}

--- a/internal/clients/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/clients/dbaas/postgrescluster/postgrescluster.go
@@ -47,7 +47,7 @@ func (cp *ClusterAPIClient) CheckDuplicateCluster(ctx context.Context, clusterNa
 							if *locationOk == location {
 								matchedItems = append(matchedItems, item)
 							} else {
-								return nil, fmt.Errorf("error: found cluster with the name %v, but immutable property location %v", clusterName, *locationOk)
+								return nil, fmt.Errorf("error: found cluster with the name %v, but immutable property location. expected: %v actual: %v", clusterName, location, *locationOk)
 							}
 						}
 					}

--- a/internal/clients/k8s/k8scluster/cluster.go
+++ b/internal/clients/k8s/k8scluster/cluster.go
@@ -34,12 +34,12 @@ type Client interface {
 
 // CheckDuplicateK8sCluster based on clusterName
 func (cp *APIClient) CheckDuplicateK8sCluster(ctx context.Context, clusterName string) (*sdkgo.KubernetesCluster, error) { // nolint: gocyclo
-	datacenters, _, err := cp.ComputeClient.KubernetesApi.K8sGet(ctx).Execute()
+	kubernetesClusters, _, err := cp.ComputeClient.KubernetesApi.K8sGet(ctx).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
 	}
 	matchedItems := make([]sdkgo.KubernetesCluster, 0)
-	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+	if itemsOk, ok := kubernetesClusters.GetItemsOk(); ok && itemsOk != nil {
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {

--- a/internal/clients/k8s/k8scluster/cluster.go
+++ b/internal/clients/k8s/k8scluster/cluster.go
@@ -2,6 +2,7 @@ package k8scluster
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	sdkgo "github.com/ionos-cloud/sdk-go/v6"
@@ -20,6 +21,8 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service K8s Cluster methods
 type Client interface {
+	CheckDuplicateK8sCluster(ctx context.Context, clusterName string) (*sdkgo.KubernetesCluster, error)
+	GetK8sClusterID(cluster *sdkgo.KubernetesCluster) (string, error)
 	GetK8sCluster(ctx context.Context, clusterID string) (sdkgo.KubernetesCluster, *sdkgo.APIResponse, error)
 	GetKubeConfig(ctx context.Context, clusterID string) (string, *sdkgo.APIResponse, error)
 	CreateK8sCluster(ctx context.Context, cluster sdkgo.KubernetesClusterForPost) (sdkgo.KubernetesCluster, *sdkgo.APIResponse, error)
@@ -27,6 +30,44 @@ type Client interface {
 	DeleteK8sCluster(ctx context.Context, clusterID string) (*sdkgo.APIResponse, error)
 	HasActiveK8sNodePools(ctx context.Context, clusterID string) (bool, error)
 	GetAPIClient() *sdkgo.APIClient
+}
+
+// CheckDuplicateK8sCluster based on clusterName
+func (cp *APIClient) CheckDuplicateK8sCluster(ctx context.Context, clusterName string) (*sdkgo.KubernetesCluster, error) { // nolint: gocyclo
+	datacenters, _, err := cp.ComputeClient.KubernetesApi.K8sGet(ctx).Execute()
+	if err != nil {
+		return nil, err
+	}
+	matchedItems := make([]sdkgo.KubernetesCluster, 0)
+	if itemsOk, ok := datacenters.GetItemsOk(); ok && itemsOk != nil {
+		for _, item := range *itemsOk {
+			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
+				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
+					if *nameOk == clusterName {
+						matchedItems = append(matchedItems, item)
+					}
+				}
+			}
+		}
+	}
+	if len(matchedItems) == 0 {
+		return nil, nil
+	}
+	if len(matchedItems) > 1 {
+		return nil, fmt.Errorf("error: found multiple clusters with the name %v", clusterName)
+	}
+	return &matchedItems[0], nil
+}
+
+// GetK8sClusterID based on cluster
+func (cp *APIClient) GetK8sClusterID(cluster *sdkgo.KubernetesCluster) (string, error) {
+	if cluster != nil {
+		if idOk, ok := cluster.GetIdOk(); ok && idOk != nil {
+			return *idOk, nil
+		}
+		return "", fmt.Errorf("error: getting cluster id")
+	}
+	return "", nil
 }
 
 // GetK8sCluster based on clusterID

--- a/internal/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/clients/k8s/k8snodepool/nodepool.go
@@ -21,7 +21,7 @@ type APIClient struct {
 
 // Client is a wrapper around IONOS Service K8s Cluster methods
 type Client interface {
-	CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodepoolName string, cr *v1alpha1.NodePool) (*sdkgo.KubernetesNodePool, error)
+	CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodePoolName string, cr *v1alpha1.NodePool) (*sdkgo.KubernetesNodePool, error)
 	GetK8sNodePoolID(nodepool *sdkgo.KubernetesNodePool) (string, error)
 	GetK8sNodePool(ctx context.Context, clusterID, nodepoolID string) (sdkgo.KubernetesNodePool, *sdkgo.APIResponse, error)
 	CreateK8sNodePool(ctx context.Context, clusterID string, nodepool sdkgo.KubernetesNodePoolForPost) (sdkgo.KubernetesNodePool, *sdkgo.APIResponse, error)
@@ -30,8 +30,8 @@ type Client interface {
 	GetAPIClient() *sdkgo.APIClient
 }
 
-// CheckDuplicateK8sNodePool based on clusterID, nodepoolName
-func (cp *APIClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodepoolName string, cr *v1alpha1.NodePool) (*sdkgo.KubernetesNodePool, error) { // nolint: gocyclo
+// CheckDuplicateK8sNodePool based on clusterID, nodepoolName and on multiple properties for CR spec
+func (cp *APIClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodePoolName string, cr *v1alpha1.NodePool) (*sdkgo.KubernetesNodePool, error) { // nolint: gocyclo
 	nodePools, _, err := cp.ComputeClient.KubernetesApi.K8sNodepoolsGet(ctx, clusterID).Depth(utils.DepthQueryParam).Execute()
 	if err != nil {
 		return nil, err
@@ -41,40 +41,40 @@ func (cp *APIClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, n
 		for _, item := range *itemsOk {
 			if propertiesOk, ok := item.GetPropertiesOk(); ok && propertiesOk != nil {
 				if nameOk, ok := propertiesOk.GetNameOk(); ok && nameOk != nil {
-					if *nameOk == nodepoolName {
+					if *nameOk == nodePoolName {
 						if cpuFamilyOk, ok := propertiesOk.GetCpuFamilyOk(); ok && cpuFamilyOk != nil && cr.Spec.ForProvider.CPUFamily != "" {
 							if *cpuFamilyOk != cr.Spec.ForProvider.CPUFamily {
-								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property cpu family different. expected: %v actual: %v", nodepoolName, cr.Spec.ForProvider.CPUFamily, *cpuFamilyOk)
+								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property cpuFamily different. expected: %v actual: %v", nodePoolName, cr.Spec.ForProvider.CPUFamily, *cpuFamilyOk)
 							}
 						}
 						if coresCountOk, ok := propertiesOk.GetCoresCountOk(); ok && coresCountOk != nil {
 							if *coresCountOk != cr.Spec.ForProvider.CoresCount {
-								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property cores count different. expected: %v actual: %v", nodepoolName, cr.Spec.ForProvider.CoresCount, *coresCountOk)
+								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property coresCount different. expected: %v actual: %v", nodePoolName, cr.Spec.ForProvider.CoresCount, *coresCountOk)
 							}
 						}
 						if ramSizeOk, ok := propertiesOk.GetRamSizeOk(); ok && ramSizeOk != nil {
 							if *ramSizeOk != cr.Spec.ForProvider.RAMSize {
-								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property ram size different. expected: %v actual: %v", nodepoolName, cr.Spec.ForProvider.RAMSize, *ramSizeOk)
+								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property ramSize different. expected: %v actual: %v", nodePoolName, cr.Spec.ForProvider.RAMSize, *ramSizeOk)
 							}
 						}
 						if availabilityZoneOk, ok := propertiesOk.GetAvailabilityZoneOk(); ok && availabilityZoneOk != nil {
 							if *availabilityZoneOk != cr.Spec.ForProvider.AvailabilityZone {
-								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property availability zone different. expected: %v actual: %v", nodepoolName, cr.Spec.ForProvider.AvailabilityZone, *availabilityZoneOk)
+								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property availabilityZone different. expected: %v actual: %v", nodePoolName, cr.Spec.ForProvider.AvailabilityZone, *availabilityZoneOk)
 							}
 						}
 						if storageTypeOk, ok := propertiesOk.GetStorageTypeOk(); ok && storageTypeOk != nil {
 							if *storageTypeOk != cr.Spec.ForProvider.StorageType {
-								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property storage type different. expected: %v actual: %v", nodepoolName, cr.Spec.ForProvider.StorageType, *storageTypeOk)
+								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property storageType different. expected: %v actual: %v", nodePoolName, cr.Spec.ForProvider.StorageType, *storageTypeOk)
 							}
 						}
 						if storageSizeOk, ok := propertiesOk.GetStorageSizeOk(); ok && storageSizeOk != nil {
 							if *storageSizeOk != cr.Spec.ForProvider.StorageSize {
-								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property storage size different. expected: %v actual: %v", nodepoolName, cr.Spec.ForProvider.StorageSize, *storageSizeOk)
+								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property storageSize different. expected: %v actual: %v", nodePoolName, cr.Spec.ForProvider.StorageSize, *storageSizeOk)
 							}
 						}
 						if datacenterIDOk, ok := propertiesOk.GetDatacenterIdOk(); ok && datacenterIDOk != nil {
 							if *datacenterIDOk != cr.Spec.ForProvider.DatacenterCfg.DatacenterID {
-								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property datacenter id different. expected: %v actual: %v", nodepoolName, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, *datacenterIDOk)
+								return nil, fmt.Errorf("error: found nodepool with the name %v, but immutable property datacenterId different. expected: %v actual: %v", nodePoolName, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, *datacenterIDOk)
 							}
 						}
 						matchedItems = append(matchedItems, item)
@@ -87,7 +87,7 @@ func (cp *APIClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, n
 		return nil, nil
 	}
 	if len(matchedItems) > 1 {
-		return nil, fmt.Errorf("error: found multiple nodepools with the name %v", nodepoolName)
+		return nil, fmt.Errorf("error: found multiple nodepools with the name %v", nodePoolName)
 	}
 	return &matchedItems[0], nil
 }

--- a/internal/controller/alb/applicationloadbalancer/applicationloadbalancer.go
+++ b/internal/controller/alb/applicationloadbalancer/applicationloadbalancer.go
@@ -19,10 +19,8 @@ package applicationloadbalancer
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/pkg/errors"
 	"github.com/rung/go-safecast"
 	"k8s.io/client-go/util/workqueue"
@@ -46,12 +44,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/alb/applicationloadbalancer"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/ipblock"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotApplicationLoadBalancer = "managed resource is not a ApplicationLoadBalancer custom resource"
 
 // Setup adds a controller that reconciles ApplicationLoadBalancer managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.ApplicationLoadBalancerGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -66,12 +65,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithCreationGracePeriod(creationGracePeriod),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/alb/forwardingrule/forwardingrule.go
+++ b/internal/controller/alb/forwardingrule/forwardingrule.go
@@ -50,7 +50,7 @@ import (
 const errNotForwardingRule = "managed resource is not a ApplicationLoadBalancer ForwardingRule custom resource"
 
 // Setup adds a controller that reconciles ForwardingRule managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.ForwardingRuleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,9 +62,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.ForwardingRuleGroupVersionKind),
 			managed.WithExternalConnecter(&connectorForwardingRule{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithCreationGracePeriod(creationGracePeriod),
@@ -77,9 +78,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorForwardingRule is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorForwardingRule struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -94,9 +96,10 @@ func (c *connectorForwardingRule) Connect(ctx context.Context, mg resource.Manag
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalForwardingRule{
-		service:        &forwardingrule.APIClient{IonosServices: svc},
-		ipBlockService: &ipblock.APIClient{IonosServices: svc},
-		log:            c.log}, err
+		service:              &forwardingrule.APIClient{IonosServices: svc},
+		ipBlockService:       &ipblock.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -104,9 +107,10 @@ func (c *connectorForwardingRule) Connect(ctx context.Context, mg resource.Manag
 type externalForwardingRule struct {
 	// A 'client' used to connect to the externalForwardingRule resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service        forwardingrule.Client
-	ipBlockService ipblock.Client
-	log            logging.Logger
+	service              forwardingrule.Client
+	ipBlockService       ipblock.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 func (c *externalForwardingRule) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) { // nolint:gocyclo
@@ -148,7 +152,6 @@ func (c *externalForwardingRule) Create(ctx context.Context, mg resource.Managed
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotForwardingRule)
 	}
-
 	cr.SetConditions(xpv1.Creating())
 	// Check external name in order to avoid duplicates,
 	// since the creation requests take longer than other resources.
@@ -159,23 +162,25 @@ func (c *externalForwardingRule) Create(ctx context.Context, mg resource.Managed
 		return managed.ExternalCreation{}, nil
 	}
 
-	// ForwardingRules should have unique names per application load balancer.
-	// Check if there are any existing forwarding rules with the same name.
-	// If there are multiple, an error will be returned.
-	instance, err := c.service.CheckDuplicateForwardingRule(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID,
-		cr.Spec.ForProvider.ALBCfg.ApplicationLoadBalancerID, cr.Spec.ForProvider.Name)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	forwardingRuleID, err := c.service.GetForwardingRuleID(instance)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	if forwardingRuleID != "" {
-		// "Import" existing server.
-		cr.Status.AtProvider.ForwardingRuleID = forwardingRuleID
-		meta.SetExternalName(cr, forwardingRuleID)
-		return managed.ExternalCreation{}, nil
+	if c.isUniqueNamesEnabled {
+		// ForwardingRules should have unique names per application load balancer.
+		// Check if there are any existing forwarding rules with the same name.
+		// If there are multiple, an error will be returned.
+		instance, err := c.service.CheckDuplicateForwardingRule(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID,
+			cr.Spec.ForProvider.ALBCfg.ApplicationLoadBalancerID, cr.Spec.ForProvider.Name)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		forwardingRuleID, err := c.service.GetForwardingRuleID(instance)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		if forwardingRuleID != "" {
+			// "Import" existing forwarding rule.
+			cr.Status.AtProvider.ForwardingRuleID = forwardingRuleID
+			meta.SetExternalName(cr, forwardingRuleID)
+			return managed.ExternalCreation{}, nil
+		}
 	}
 
 	listenerIP, err := c.getIPSet(ctx, cr)
@@ -196,7 +201,6 @@ func (c *externalForwardingRule) Create(ctx context.Context, mg resource.Managed
 		}
 		return creation, retErr
 	}
-
 	// Set External Name
 	cr.Status.AtProvider.ForwardingRuleID = *newInstance.Id
 	meta.SetExternalName(cr, *newInstance.Id)

--- a/internal/controller/alb/forwardingrule/forwardingrule.go
+++ b/internal/controller/alb/forwardingrule/forwardingrule.go
@@ -19,10 +19,8 @@ package forwardingrule
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,12 +43,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/alb/forwardingrule"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/ipblock"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotForwardingRule = "managed resource is not a ApplicationLoadBalancer ForwardingRule custom resource"
 
 // Setup adds a controller that reconciles ForwardingRule managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.ForwardingRuleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,12 +64,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithCreationGracePeriod(creationGracePeriod),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/alb/targetgroup/targetgroup.go
+++ b/internal/controller/alb/targetgroup/targetgroup.go
@@ -19,7 +19,6 @@ package targetgroup
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -41,12 +40,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/alb/targetgroup"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotTargetGroup = "managed resource is not a TargetGroup custom resource"
 
 // Setup adds a controller that reconciles TargetGroup managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.TargetGroupGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -61,12 +61,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll ti
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithCreationGracePeriod(creationGracePeriod),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/backup/backupunit/backupunit.go
+++ b/internal/controller/backup/backupunit/backupunit.go
@@ -148,7 +148,7 @@ func (c *externalBackupUnit) Create(ctx context.Context, mg resource.Managed) (m
 		// BackupUnits should have unique names per account.
 		// Check if there are any existing backup units with the same name.
 		// If there are multiple, an error will be returned.
-		instance, err := c.service.CheckDuplicateBackupUnit(ctx, cr.Spec.ForProvider.Name)
+		instance, err := c.service.CheckDuplicateBackupUnit(ctx, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.Email)
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}

--- a/internal/controller/backup/backupunit/backupunit.go
+++ b/internal/controller/backup/backupunit/backupunit.go
@@ -45,7 +45,7 @@ import (
 const errNotBackupUnit = "managed resource is not a BackupUnit custom resource"
 
 // Setup adds a controller that reconciles BackupUnit managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.BackupUnitGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -57,9 +57,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.BackupUnitGroupVersionKind),
 			managed.WithExternalConnecter(&connectorBackupUnit{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(poll),
@@ -72,9 +73,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorBackupUnit is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorBackupUnit struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -89,8 +91,9 @@ func (c *connectorBackupUnit) Connect(ctx context.Context, mg resource.Managed) 
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalBackupUnit{
-		service: &backupunit.APIClient{IonosServices: svc},
-		log:     c.log}, err
+		service:              &backupunit.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -98,8 +101,9 @@ func (c *connectorBackupUnit) Connect(ctx context.Context, mg resource.Managed) 
 type externalBackupUnit struct {
 	// A 'client' used to connect to the externalBackupUnit resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service backupunit.Client
-	log     logging.Logger
+	service              backupunit.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 func (c *externalBackupUnit) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -135,35 +139,35 @@ func (c *externalBackupUnit) Create(ctx context.Context, mg resource.Managed) (m
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotBackupUnit)
 	}
-
 	cr.SetConditions(xpv1.Creating())
 	if cr.Status.AtProvider.State == compute.BUSY {
 		return managed.ExternalCreation{}, nil
 	}
 
-	// BackupUnits should have unique names per account.
-	// Check if there are any existing backup units with the same name.
-	// If there are multiple, an error will be returned.
-	instance, err := c.service.CheckDuplicateBackupUnit(ctx, cr.Spec.ForProvider.Name)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	backupUnitID, err := c.service.GetBackupUnitID(instance)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	if backupUnitID != "" {
-		// "Import" existing datacenter.
-		cr.Status.AtProvider.BackupUnitID = backupUnitID
-		meta.SetExternalName(cr, backupUnitID)
-		return managed.ExternalCreation{}, nil
+	if c.isUniqueNamesEnabled {
+		// BackupUnits should have unique names per account.
+		// Check if there are any existing backup units with the same name.
+		// If there are multiple, an error will be returned.
+		instance, err := c.service.CheckDuplicateBackupUnit(ctx, cr.Spec.ForProvider.Name)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		backupUnitID, err := c.service.GetBackupUnitID(instance)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		if backupUnitID != "" {
+			// "Import" existing backup unit.
+			cr.Status.AtProvider.BackupUnitID = backupUnitID
+			meta.SetExternalName(cr, backupUnitID)
+			return managed.ExternalCreation{}, nil
+		}
 	}
 
 	instanceInput, err := backupunit.GenerateCreateBackupUnitInput(cr)
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
-
 	newInstance, apiResponse, err := c.service.CreateBackupUnit(ctx, *instanceInput)
 	creation := managed.ExternalCreation{ConnectionDetails: managed.ConnectionDetails{}}
 	if err != nil {
@@ -173,7 +177,6 @@ func (c *externalBackupUnit) Create(ctx context.Context, mg resource.Managed) (m
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return creation, err
 	}
-
 	// Set External Name
 	cr.Status.AtProvider.BackupUnitID = *newInstance.Id
 	meta.SetExternalName(cr, *newInstance.Id)

--- a/internal/controller/backup/backupunit/backupunit.go
+++ b/internal/controller/backup/backupunit/backupunit.go
@@ -19,7 +19,6 @@ package backupunit
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
@@ -40,12 +39,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/backup/backupunit"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotBackupUnit = "managed resource is not a BackupUnit custom resource"
 
 // Setup adds a controller that reconciles BackupUnit managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.BackupUnitGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -60,12 +60,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/cubeserver/cubeserver.go
+++ b/internal/controller/compute/cubeserver/cubeserver.go
@@ -19,7 +19,6 @@ package cubeserver
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -43,12 +42,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/server"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/template"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/volume"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotCubeServer = "managed resource is not a Cube Server custom resource"
 
 // Setup adds a controller that reconciles Server managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.CubeServerGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -63,12 +63,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/cubeserver/cubeserver.go
+++ b/internal/controller/compute/cubeserver/cubeserver.go
@@ -48,7 +48,7 @@ import (
 const errNotCubeServer = "managed resource is not a Cube Server custom resource"
 
 // Setup adds a controller that reconciles Server managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.CubeServerGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -60,9 +60,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.CubeServerGroupVersionKind),
 			managed.WithExternalConnecter(&connectorServer{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(poll),
@@ -75,9 +76,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorServer is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorServer struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -92,10 +94,11 @@ func (c *connectorServer) Connect(ctx context.Context, mg resource.Managed) (man
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalServer{
-		service:         &server.APIClient{IonosServices: svc},
-		serviceVolume:   &volume.APIClient{IonosServices: svc},
-		serviceTemplate: &template.APIClient{IonosServices: svc},
-		log:             c.log}, err
+		service:              &server.APIClient{IonosServices: svc},
+		serviceVolume:        &volume.APIClient{IonosServices: svc},
+		serviceTemplate:      &template.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -103,10 +106,11 @@ func (c *connectorServer) Connect(ctx context.Context, mg resource.Managed) (man
 type externalServer struct {
 	// A 'client' used to connect to the externalServer resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service         server.Client
-	serviceVolume   volume.Client
-	serviceTemplate template.Client
-	log             logging.Logger
+	service              server.Client
+	serviceVolume        volume.Client
+	serviceTemplate      template.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 func (c *externalServer) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) { // nolint:gocyclo
@@ -148,33 +152,34 @@ func (c *externalServer) Observe(ctx context.Context, mg resource.Managed) (mana
 	}, nil
 }
 
-func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) { // nolint: gocyclo
 	cr, ok := mg.(*v1alpha1.CubeServer)
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotCubeServer)
 	}
-
 	cr.SetConditions(xpv1.Creating())
 	if cr.Status.AtProvider.State == compute.BUSY {
 		return managed.ExternalCreation{}, nil
 	}
 
-	// Servers should have unique names per datacenter.
-	// Check if there are any existing servers with the same name.
-	// If there are multiple, an error will be returned.
-	instance, err := c.service.CheckDuplicateServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.CPUFamily)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	serverID, err := c.service.GetServerID(instance)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	if serverID != "" {
-		// "Import" existing server.
-		cr.Status.AtProvider.ServerID = serverID
-		meta.SetExternalName(cr, serverID)
-		return managed.ExternalCreation{}, nil
+	if c.isUniqueNamesEnabled {
+		// Servers should have unique names per datacenter.
+		// Check if there are any existing servers with the same name.
+		// If there are multiple, an error will be returned.
+		instance, err := c.service.CheckDuplicateServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.CPUFamily)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		serverID, err := c.service.GetServerID(instance)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		if serverID != "" {
+			// "Import" existing server.
+			cr.Status.AtProvider.ServerID = serverID
+			meta.SetExternalName(cr, serverID)
+			return managed.ExternalCreation{}, nil
+		}
 	}
 
 	// Resolve TemplateID
@@ -182,12 +187,11 @@ func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (manag
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
-
+	// Create new cube server based on the properties set
 	instanceInput, err := server.GenerateCreateCubeServerInput(cr, templateID)
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
-
 	newInstance, apiResponse, err := c.service.CreateServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, *instanceInput)
 	creation := managed.ExternalCreation{ConnectionDetails: managed.ConnectionDetails{}}
 	if err != nil {
@@ -197,7 +201,6 @@ func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (manag
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return creation, err
 	}
-
 	// Set External Name
 	cr.Status.AtProvider.ServerID = *newInstance.Id
 	meta.SetExternalName(cr, *newInstance.Id)

--- a/internal/controller/compute/cubeserver/cubeserver.go
+++ b/internal/controller/compute/cubeserver/cubeserver.go
@@ -158,6 +158,25 @@ func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (manag
 	if cr.Status.AtProvider.State == compute.BUSY {
 		return managed.ExternalCreation{}, nil
 	}
+
+	// Servers should have unique names per datacenter.
+	// Check if there are any existing servers with the same name.
+	// If there are multiple, an error will be returned.
+	instance, err := c.service.CheckDuplicateServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.CPUFamily)
+	if err != nil {
+		return managed.ExternalCreation{}, err
+	}
+	serverID, err := c.service.GetServerID(instance)
+	if err != nil {
+		return managed.ExternalCreation{}, err
+	}
+	if serverID != "" {
+		// "Import" existing server.
+		cr.Status.AtProvider.ServerID = serverID
+		meta.SetExternalName(cr, serverID)
+		return managed.ExternalCreation{}, nil
+	}
+
 	// Resolve TemplateID
 	templateID, err := getTemplateID(ctx, c, cr)
 	if err != nil {
@@ -169,7 +188,7 @@ func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (manag
 		return managed.ExternalCreation{}, err
 	}
 
-	instance, apiResponse, err := c.service.CreateServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, *instanceInput)
+	newInstance, apiResponse, err := c.service.CreateServer(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, *instanceInput)
 	creation := managed.ExternalCreation{ConnectionDetails: managed.ConnectionDetails{}}
 	if err != nil {
 		retErr := fmt.Errorf("failed to create cube server. error: %w", err)
@@ -180,8 +199,8 @@ func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (manag
 	}
 
 	// Set External Name
-	cr.Status.AtProvider.ServerID = *instance.Id
-	meta.SetExternalName(cr, *instance.Id)
+	cr.Status.AtProvider.ServerID = *newInstance.Id
+	meta.SetExternalName(cr, *newInstance.Id)
 	return creation, nil
 }
 

--- a/internal/controller/compute/datacenter/datacenter.go
+++ b/internal/controller/compute/datacenter/datacenter.go
@@ -19,7 +19,6 @@ package datacenter
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
@@ -40,12 +39,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/datacenter"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotDatacenter = "managed resource is not a Datacenter custom resource"
 
 // Setup adds a controller that reconciles Datacenter managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.DatacenterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -60,12 +60,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/datacenter/datacenter.go
+++ b/internal/controller/compute/datacenter/datacenter.go
@@ -45,7 +45,7 @@ import (
 const errNotDatacenter = "managed resource is not a Datacenter custom resource"
 
 // Setup adds a controller that reconciles Datacenter managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.DatacenterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -57,9 +57,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.DatacenterGroupVersionKind),
 			managed.WithExternalConnecter(&connectorDatacenter{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(poll),
@@ -72,9 +73,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorDatacenter is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorDatacenter struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -89,8 +91,9 @@ func (c *connectorDatacenter) Connect(ctx context.Context, mg resource.Managed) 
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalDatacenter{
-		service: &datacenter.APIClient{IonosServices: svc},
-		log:     c.log}, err
+		service:              &datacenter.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -98,8 +101,9 @@ func (c *connectorDatacenter) Connect(ctx context.Context, mg resource.Managed) 
 type externalDatacenter struct {
 	// A 'client' used to connect to the externalDatacenter resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service datacenter.Client
-	log     logging.Logger
+	service              datacenter.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 func (c *externalDatacenter) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -136,28 +140,29 @@ func (c *externalDatacenter) Create(ctx context.Context, mg resource.Managed) (m
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotDatacenter)
 	}
-
 	cr.SetConditions(xpv1.Creating())
 	if cr.Status.AtProvider.State == compute.BUSY {
 		return managed.ExternalCreation{}, nil
 	}
 
-	// Datacenters should have unique names per account.
-	// Check if there are any existing datacenters with the same name.
-	// If there are multiple, an error will be returned.
-	instance, err := c.service.CheckDuplicateDatacenter(ctx, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.Location)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	datacenterID, err := c.service.GetDatacenterID(instance)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	if datacenterID != "" {
-		// "Import" existing datacenter.
-		cr.Status.AtProvider.DatacenterID = datacenterID
-		meta.SetExternalName(cr, datacenterID)
-		return managed.ExternalCreation{}, nil
+	if c.isUniqueNamesEnabled {
+		// Datacenters should have unique names per account.
+		// Check if there are any existing datacenters with the same name.
+		// If there are multiple, an error will be returned.
+		instance, err := c.service.CheckDuplicateDatacenter(ctx, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.Location)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		datacenterID, err := c.service.GetDatacenterID(instance)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		if datacenterID != "" {
+			// "Import" existing datacenter.
+			cr.Status.AtProvider.DatacenterID = datacenterID
+			meta.SetExternalName(cr, datacenterID)
+			return managed.ExternalCreation{}, nil
+		}
 	}
 
 	// Create new datacenter instance accordingly

--- a/internal/controller/compute/firewallrule/firewallrule.go
+++ b/internal/controller/compute/firewallrule/firewallrule.go
@@ -19,7 +19,6 @@ package firewallrule
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
@@ -41,12 +40,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/firewallrule"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/ipblock"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotFirewallRule = "managed resource is not a FirewallRule custom resource"
 
 // Setup adds a controller that reconciles FirewallRule managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.FirewallRuleGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -61,10 +61,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
-			managed.WithPollInterval(poll),
-			managed.WithCreationGracePeriod(creationGracePeriod),
-			managed.WithTimeout(timeout),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
+			managed.WithTimeout(opts.GetTimeout()),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))

--- a/internal/controller/compute/ipblock/ipblock.go
+++ b/internal/controller/compute/ipblock/ipblock.go
@@ -19,7 +19,6 @@ package ipblock
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -41,12 +40,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/ipblock"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotIPBlock = "managed resource is not a IPBlock custom resource"
 
 // Setup adds a controller that reconciles IPBlock managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.IPBlockGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -61,12 +61,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/ipblock/ipblock.go
+++ b/internal/controller/compute/ipblock/ipblock.go
@@ -46,7 +46,7 @@ import (
 const errNotIPBlock = "managed resource is not a IPBlock custom resource"
 
 // Setup adds a controller that reconciles IPBlock managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.IPBlockGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -58,9 +58,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.IPBlockGroupVersionKind),
 			managed.WithExternalConnecter(&connectorIPBlock{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(poll),
@@ -73,9 +74,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorIPBlock is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorIPBlock struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -90,8 +92,9 @@ func (c *connectorIPBlock) Connect(ctx context.Context, mg resource.Managed) (ma
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalIPBlock{
-		service: &ipblock.APIClient{IonosServices: svc},
-		log:     c.log}, err
+		service:              &ipblock.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -99,8 +102,9 @@ func (c *connectorIPBlock) Connect(ctx context.Context, mg resource.Managed) (ma
 type externalIPBlock struct {
 	// A 'client' used to connect to the externalIPBlock resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service ipblock.Client
-	log     logging.Logger
+	service              ipblock.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 func (c *externalIPBlock) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -140,35 +144,35 @@ func (c *externalIPBlock) Create(ctx context.Context, mg resource.Managed) (mana
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotIPBlock)
 	}
-
 	cr.SetConditions(xpv1.Creating())
 	if cr.Status.AtProvider.State == compute.BUSY {
 		return managed.ExternalCreation{}, nil
 	}
 
-	// IPBlocks should have unique names per account.
-	// Check if there are any existing volumes with the same name.
-	// If there are multiple, an error will be returned.
-	instance, err := c.service.CheckDuplicateIPBlock(ctx, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.Location)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	ipBlockID, err := c.service.GetIPBlockID(instance)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	if ipBlockID != "" {
-		// "Import" existing IPBlock.
-		cr.Status.AtProvider.IPBlockID = ipBlockID
-		meta.SetExternalName(cr, ipBlockID)
-		return managed.ExternalCreation{}, nil
+	if c.isUniqueNamesEnabled {
+		// IPBlocks should have unique names per account.
+		// Check if there are any existing volumes with the same name.
+		// If there are multiple, an error will be returned.
+		instance, err := c.service.CheckDuplicateIPBlock(ctx, cr.Spec.ForProvider.Name, cr.Spec.ForProvider.Location)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		ipBlockID, err := c.service.GetIPBlockID(instance)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		if ipBlockID != "" {
+			// "Import" existing IPBlock.
+			cr.Status.AtProvider.IPBlockID = ipBlockID
+			meta.SetExternalName(cr, ipBlockID)
+			return managed.ExternalCreation{}, nil
+		}
 	}
 
 	instanceInput, err := ipblock.GenerateCreateIPBlockInput(cr)
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
-
 	newInstance, apiResponse, err := c.service.CreateIPBlock(ctx, *instanceInput)
 	creation := managed.ExternalCreation{ConnectionDetails: managed.ConnectionDetails{}}
 	if err != nil {
@@ -178,7 +182,6 @@ func (c *externalIPBlock) Create(ctx context.Context, mg resource.Managed) (mana
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return creation, err
 	}
-
 	// Set External Name
 	cr.Status.AtProvider.IPBlockID = *newInstance.Id
 	meta.SetExternalName(cr, *newInstance.Id)

--- a/internal/controller/compute/ipfailover/ipfailover.go
+++ b/internal/controller/compute/ipfailover/ipfailover.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
@@ -42,12 +41,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/ipblock"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/lan"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotIPFailover = "managed resource is not a IPFailover custom resource"
 
 // Setup adds a controller that reconciles IPFailover managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.IPFailoverGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,12 +62,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/ipfailover/ipfailover.go
+++ b/internal/controller/compute/ipfailover/ipfailover.go
@@ -47,7 +47,7 @@ import (
 const errNotIPFailover = "managed resource is not a IPFailover custom resource"
 
 // Setup adds a controller that reconciles IPFailover managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.IPFailoverGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -59,9 +59,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.IPFailoverGroupVersionKind),
 			managed.WithExternalConnecter(&connectorIPFailover{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(poll),
@@ -74,9 +75,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorIPFailover is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorIPFailover struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -91,9 +93,10 @@ func (c *connectorIPFailover) Connect(ctx context.Context, mg resource.Managed) 
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalIPFailover{
-		service:        &lan.APIClient{IonosServices: svc},
-		ipBlockService: &ipblock.APIClient{IonosServices: svc},
-		log:            c.log}, err
+		service:              &lan.APIClient{IonosServices: svc},
+		ipBlockService:       &ipblock.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -101,9 +104,10 @@ func (c *connectorIPFailover) Connect(ctx context.Context, mg resource.Managed) 
 type externalIPFailover struct {
 	// A 'client' used to connect to the externalIPFailover resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service        lan.Client
-	ipBlockService ipblock.Client
-	log            logging.Logger
+	service              lan.Client
+	ipBlockService       ipblock.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 var (

--- a/internal/controller/compute/lan/lan.go
+++ b/internal/controller/compute/lan/lan.go
@@ -45,7 +45,7 @@ import (
 const errNotLan = "managed resource is not a Lan custom resource"
 
 // Setup adds a controller that reconciles Lan managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, createGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, createGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.LanGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -56,9 +56,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.LanGroupVersionKind),
 			managed.WithExternalConnecter(&connectorLan{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(poll),
@@ -71,9 +72,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorLan is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorLan struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -88,8 +90,9 @@ func (c *connectorLan) Connect(ctx context.Context, mg resource.Managed) (manage
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalLan{
-		service: &lan.APIClient{IonosServices: svc},
-		log:     c.log}, err
+		service:              &lan.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -97,8 +100,9 @@ func (c *connectorLan) Connect(ctx context.Context, mg resource.Managed) (manage
 type externalLan struct {
 	// A 'client' used to connect to the externalLan resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service lan.Client
-	log     logging.Logger
+	service              lan.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 func (c *externalLan) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -136,34 +140,35 @@ func (c *externalLan) Create(ctx context.Context, mg resource.Managed) (managed.
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotLan)
 	}
-
 	cr.SetConditions(xpv1.Creating())
 	if cr.Status.AtProvider.State == compute.BUSY {
 		return managed.ExternalCreation{}, nil
 	}
-	// Lans should have unique names per datacenter.
-	// Check if there are any existing lans with the same name.
-	// If there are multiple, an error will be returned.
-	instance, err := c.service.CheckDuplicateLan(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.Name)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	lanID, err := c.service.GetLanID(instance)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	if lanID != "" {
-		// "Import" existing lan.
-		cr.Status.AtProvider.LanID = lanID
-		meta.SetExternalName(cr, lanID)
-		return managed.ExternalCreation{}, nil
+
+	if c.isUniqueNamesEnabled {
+		// Lans should have unique names per datacenter.
+		// Check if there are any existing lans with the same name.
+		// If there are multiple, an error will be returned.
+		instance, err := c.service.CheckDuplicateLan(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.Name)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		lanID, err := c.service.GetLanID(instance)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		if lanID != "" {
+			// "Import" existing lan.
+			cr.Status.AtProvider.LanID = lanID
+			meta.SetExternalName(cr, lanID)
+			return managed.ExternalCreation{}, nil
+		}
 	}
 
 	instanceInput, err := lan.GenerateCreateLanInput(cr)
 	if err != nil {
 		return managed.ExternalCreation{}, err
 	}
-
 	newInstance, apiResponse, err := c.service.CreateLan(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, *instanceInput)
 	creation := managed.ExternalCreation{ConnectionDetails: managed.ConnectionDetails{}}
 	if err != nil {
@@ -173,7 +178,6 @@ func (c *externalLan) Create(ctx context.Context, mg resource.Managed) (managed.
 	if err = compute.WaitForRequest(ctx, c.service.GetAPIClient(), apiResponse); err != nil {
 		return creation, err
 	}
-
 	// Set External Name
 	cr.Status.AtProvider.LanID = *newInstance.Id
 	meta.SetExternalName(cr, *newInstance.Id)

--- a/internal/controller/compute/lan/lan.go
+++ b/internal/controller/compute/lan/lan.go
@@ -19,7 +19,6 @@ package lan
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
@@ -40,12 +39,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/lan"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotLan = "managed resource is not a Lan custom resource"
 
 // Setup adds a controller that reconciles Lan managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, createGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.LanGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -59,12 +59,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(createGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/nic/nic.go
+++ b/internal/controller/compute/nic/nic.go
@@ -173,7 +173,8 @@ func (c *externalNic) Create(ctx context.Context, mg resource.Managed) (managed.
 		// NICs should have unique names per server.
 		// Check if there are any existing volumes with the same name.
 		// If there are multiple, an error will be returned.
-		instance, err := c.service.CheckDuplicateNic(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.ServerCfg.ServerID, cr.Spec.ForProvider.Name)
+		instance, err := c.service.CheckDuplicateNic(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID,
+			cr.Spec.ForProvider.ServerCfg.ServerID, cr.Spec.ForProvider.Name)
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}

--- a/internal/controller/compute/nic/nic.go
+++ b/internal/controller/compute/nic/nic.go
@@ -19,7 +19,6 @@ package nic
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -42,12 +41,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/ipblock"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/nic"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotNic = "managed resource is not a Nic custom resource"
 
 // Setup adds a controller that reconciles Nic managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.NicGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,12 +62,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/server/server.go
+++ b/internal/controller/compute/server/server.go
@@ -163,7 +163,7 @@ func (c *externalServer) Create(ctx context.Context, mg resource.Managed) (manag
 		return managed.ExternalCreation{}, err
 	}
 	if serverID != "" {
-		// "Import" existing datacenter.
+		// "Import" existing server.
 		cr.Status.AtProvider.ServerID = serverID
 		meta.SetExternalName(cr, serverID)
 		return managed.ExternalCreation{}, nil

--- a/internal/controller/compute/server/server.go
+++ b/internal/controller/compute/server/server.go
@@ -20,12 +20,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
-
-	"github.com/google/go-cmp/cmp"
 
 	sdkgo "github.com/ionos-cloud/sdk-go/v6"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -51,7 +49,7 @@ import (
 const errNotServer = "managed resource is not a Server custom resource"
 
 // Setup adds a controller that reconciles Server managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.ServerGroupKind)
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -65,12 +63,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/compute/volume/volume.go
+++ b/internal/controller/compute/volume/volume.go
@@ -19,7 +19,6 @@ package volume
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
@@ -40,12 +39,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute/volume"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotVolume = "managed resource is not a Volume custom resource"
 
 // Setup adds a controller that reconciles Volume managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.VolumeGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -60,10 +60,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
-			managed.WithPollInterval(poll),
-			managed.WithCreationGracePeriod(creationGracePeriod),
-			managed.WithTimeout(timeout),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
+			managed.WithTimeout(opts.GetTimeout()),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))

--- a/internal/controller/compute/volume/volume.go
+++ b/internal/controller/compute/volume/volume.go
@@ -148,7 +148,9 @@ func (c *externalVolume) Create(ctx context.Context, mg resource.Managed) (manag
 		// Volumes should have unique names per datacenter.
 		// Check if there are any existing volumes with the same name.
 		// If there are multiple, an error will be returned.
-		instance, err := c.service.CheckDuplicateVolume(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID, cr.Spec.ForProvider.Name)
+		instance, err := c.service.CheckDuplicateVolume(ctx, cr.Spec.ForProvider.DatacenterCfg.DatacenterID,
+			cr.Spec.ForProvider.Name, cr.Spec.ForProvider.Type, cr.Spec.ForProvider.AvailabilityZone,
+			cr.Spec.ForProvider.LicenceType, cr.Spec.ForProvider.Image)
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}

--- a/internal/controller/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/controller/dbaas/postgrescluster/postgrescluster.go
@@ -157,7 +157,8 @@ func (c *externalCluster) Create(ctx context.Context, mg resource.Managed) (mana
 		// Clusters should have unique names per account.
 		// Check if there are any existing clusters with the same name.
 		// If there are multiple, an error will be returned.
-		instance, err := c.service.CheckDuplicateCluster(ctx, cr.Spec.ForProvider.DisplayName, cr.Spec.ForProvider.Location)
+		instance, err := c.service.CheckDuplicateCluster(ctx, cr.Spec.ForProvider.DisplayName,
+			cr.Spec.ForProvider.Location, cr.Spec.ForProvider.StorageType)
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}

--- a/internal/controller/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/controller/dbaas/postgrescluster/postgrescluster.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
-
 	"github.com/pkg/errors"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -44,12 +42,13 @@ import (
 	apisv1alpha1 "github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/v1alpha1"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/dbaas/postgrescluster"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotCluster = "managed resource is not a Cluster custom resource"
 
 // Setup adds a controller that reconciles Cluster managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.PostgresClusterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,12 +63,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/controller/dbaas/postgrescluster/postgrescluster.go
@@ -157,8 +157,7 @@ func (c *externalCluster) Create(ctx context.Context, mg resource.Managed) (mana
 		// Clusters should have unique names per account.
 		// Check if there are any existing clusters with the same name.
 		// If there are multiple, an error will be returned.
-		instance, err := c.service.CheckDuplicateCluster(ctx, cr.Spec.ForProvider.DisplayName,
-			cr.Spec.ForProvider.Location, cr.Spec.ForProvider.StorageType)
+		instance, err := c.service.CheckDuplicateCluster(ctx, cr.Spec.ForProvider.DisplayName, cr)
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}

--- a/internal/controller/ionoscloud.go
+++ b/internal/controller/ionoscloud.go
@@ -45,8 +45,8 @@ import (
 
 // Setup creates all IONOS Cloud controllers with the supplied logger
 // and adds them to the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, poll, createGracePeriod, timeout time.Duration) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, time.Duration, time.Duration, time.Duration) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, poll, createGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, time.Duration, time.Duration, time.Duration, bool) error{
 		datacenter.Setup,
 		server.Setup,
 		cubeserver.Setup,
@@ -64,7 +64,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, poll, c
 		targetgroup.Setup,
 		backupunit.Setup,
 	} {
-		if err := setup(mgr, l, wl, poll, createGracePeriod, timeout); err != nil {
+		if err := setup(mgr, l, wl, poll, createGracePeriod, timeout, uniqueNamesEnable); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/ionoscloud.go
+++ b/internal/controller/ionoscloud.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"time"
-
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -41,12 +39,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/controller/dbaas/postgrescluster"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/controller/k8s/k8scluster"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/controller/k8s/k8snodepool"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 // Setup creates all IONOS Cloud controllers with the supplied logger
 // and adds them to the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, poll, createGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
-	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, time.Duration, time.Duration, time.Duration, bool) error{
+func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, options *utils.ConfigurationOptions) error {
+	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter, *utils.ConfigurationOptions) error{
 		datacenter.Setup,
 		server.Setup,
 		cubeserver.Setup,
@@ -64,7 +63,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, poll, c
 		targetgroup.Setup,
 		backupunit.Setup,
 	} {
-		if err := setup(mgr, l, wl, poll, createGracePeriod, timeout, uniqueNamesEnable); err != nil {
+		if err := setup(mgr, l, wl, options); err != nil {
 			return err
 		}
 	}

--- a/internal/controller/k8s/k8scluster/cluster.go
+++ b/internal/controller/k8s/k8scluster/cluster.go
@@ -19,7 +19,6 @@ package k8scluster
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -42,6 +41,7 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/compute"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/k8s"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/k8s/k8scluster"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const (
@@ -49,7 +49,7 @@ const (
 )
 
 // Setup adds a controller that reconciles K8sCluster managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.ClusterGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -64,12 +64,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/controller/k8s/k8snodepool/nodepool.go
+++ b/internal/controller/k8s/k8snodepool/nodepool.go
@@ -172,7 +172,8 @@ func (c *externalNodePool) Create(ctx context.Context, mg resource.Managed) (man
 		// NodePools should have unique names per cluster.
 		// Check if there are any existing node pools with the same name.
 		// If there are multiple, an error will be returned.
-		instance, err := c.service.CheckDuplicateK8sNodePool(ctx, cr.Spec.ForProvider.ClusterCfg.ClusterID, cr.Spec.ForProvider.Name)
+		instance, err := c.service.CheckDuplicateK8sNodePool(ctx, cr.Spec.ForProvider.ClusterCfg.ClusterID,
+			cr.Spec.ForProvider.Name, cr)
 		if err != nil {
 			return managed.ExternalCreation{}, err
 		}

--- a/internal/controller/k8s/k8snodepool/nodepool.go
+++ b/internal/controller/k8s/k8snodepool/nodepool.go
@@ -50,7 +50,7 @@ import (
 const errNotK8sNodePool = "managed resource is not a K8s NodePool custom resource"
 
 // Setup adds a controller that reconciles K8sNodePool managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
 	name := managed.ControllerName(v1alpha1.NodePoolGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -62,9 +62,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.NodePoolGroupVersionKind),
 			managed.WithExternalConnecter(&connectorNodePool{
-				kube:  mgr.GetClient(),
-				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
-				log:   l}),
+				kube:                 mgr.GetClient(),
+				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+				log:                  l,
+				isUniqueNamesEnabled: uniqueNamesEnable}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(poll),
@@ -77,9 +78,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 // A connectorK8sNodePool is expected to produce an ExternalClient when its Connect method
 // is called.
 type connectorNodePool struct {
-	kube  client.Client
-	usage resource.Tracker
-	log   logging.Logger
+	kube                 client.Client
+	usage                resource.Tracker
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 // Connect typically produces an ExternalClient by:
@@ -94,12 +96,12 @@ func (c *connectorNodePool) Connect(ctx context.Context, mg resource.Managed) (m
 	}
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalNodePool{
-		service:           &k8snodepool.APIClient{IonosServices: svc},
-		clusterService:    &k8scluster.APIClient{IonosServices: svc},
-		datacenterService: &datacenter.APIClient{IonosServices: svc},
-		ipBlockService:    &ipblock.APIClient{IonosServices: svc},
-		log:               c.log,
-	}, err
+		service:              &k8snodepool.APIClient{IonosServices: svc},
+		clusterService:       &k8scluster.APIClient{IonosServices: svc},
+		datacenterService:    &datacenter.APIClient{IonosServices: svc},
+		ipBlockService:       &ipblock.APIClient{IonosServices: svc},
+		log:                  c.log,
+		isUniqueNamesEnabled: c.isUniqueNamesEnabled}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -107,11 +109,12 @@ func (c *connectorNodePool) Connect(ctx context.Context, mg resource.Managed) (m
 type externalNodePool struct {
 	// A 'client' used to connect to the externalK8sNodePool resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	service           k8snodepool.Client
-	clusterService    k8scluster.Client
-	datacenterService datacenter.Client
-	ipBlockService    ipblock.Client
-	log               logging.Logger
+	service              k8snodepool.Client
+	clusterService       k8scluster.Client
+	datacenterService    datacenter.Client
+	ipBlockService       ipblock.Client
+	log                  logging.Logger
+	isUniqueNamesEnabled bool
 }
 
 func (c *externalNodePool) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -157,32 +160,32 @@ func (c *externalNodePool) Create(ctx context.Context, mg resource.Managed) (man
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errNotK8sNodePool)
 	}
-
 	if err := c.ensureClusterIsActive(ctx, cr.Spec.ForProvider.ClusterCfg.ClusterID); err != nil {
 		return managed.ExternalCreation{}, fmt.Errorf("cluster must be active to create nodepool: %w", err)
 	}
-
 	cr.SetConditions(xpv1.Creating())
 	if cr.Status.AtProvider.State == k8s.DEPLOYING {
 		return managed.ExternalCreation{}, nil
 	}
 
-	// NodePools should have unique names per cluster.
-	// Check if there are any existing node pools with the same name.
-	// If there are multiple, an error will be returned.
-	instance, err := c.service.CheckDuplicateK8sNodePool(ctx, cr.Spec.ForProvider.ClusterCfg.ClusterID, cr.Spec.ForProvider.Name)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	nodePoolID, err := c.service.GetK8sNodePoolID(instance)
-	if err != nil {
-		return managed.ExternalCreation{}, err
-	}
-	if nodePoolID != "" {
-		// "Import" existing nodePool.
-		cr.Status.AtProvider.NodePoolID = nodePoolID
-		meta.SetExternalName(cr, nodePoolID)
-		return managed.ExternalCreation{}, nil
+	if c.isUniqueNamesEnabled {
+		// NodePools should have unique names per cluster.
+		// Check if there are any existing node pools with the same name.
+		// If there are multiple, an error will be returned.
+		instance, err := c.service.CheckDuplicateK8sNodePool(ctx, cr.Spec.ForProvider.ClusterCfg.ClusterID, cr.Spec.ForProvider.Name)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		nodePoolID, err := c.service.GetK8sNodePoolID(instance)
+		if err != nil {
+			return managed.ExternalCreation{}, err
+		}
+		if nodePoolID != "" {
+			// "Import" existing nodePool.
+			cr.Status.AtProvider.NodePoolID = nodePoolID
+			meta.SetExternalName(cr, nodePoolID)
+			return managed.ExternalCreation{}, nil
+		}
 	}
 
 	// Note: If the CPU Family is not set by the user, the Crossplane Provider IONOS Cloud
@@ -201,14 +204,12 @@ func (c *externalNodePool) Create(ctx context.Context, mg resource.Managed) (man
 		return managed.ExternalCreation{}, fmt.Errorf("failed to get public IPs: %w", err)
 	}
 	instanceInput := k8snodepool.GenerateCreateK8sNodePoolInput(cr, publicIPs)
-
 	newInstance, apiResponse, err := c.service.CreateK8sNodePool(ctx, cr.Spec.ForProvider.ClusterCfg.ClusterID, *instanceInput)
 	creation := managed.ExternalCreation{ConnectionDetails: managed.ConnectionDetails{}}
 	if err != nil {
 		retErr := fmt.Errorf("failed to create k8s nodepool. error: %w", err)
 		return creation, compute.AddAPIResponseInfo(apiResponse, retErr)
 	}
-
 	// Set External Name
 	cr.Status.AtProvider.NodePoolID = *newInstance.Id
 	meta.SetExternalName(cr, *newInstance.Id)

--- a/internal/controller/k8s/k8snodepool/nodepool.go
+++ b/internal/controller/k8s/k8snodepool/nodepool.go
@@ -19,7 +19,6 @@ package k8snodepool
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -45,12 +44,13 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/k8s"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/k8s/k8scluster"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/k8s/k8snodepool"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 )
 
 const errNotK8sNodePool = "managed resource is not a K8s NodePool custom resource"
 
 // Setup adds a controller that reconciles K8sNodePool managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, creationGracePeriod, timeout time.Duration, uniqueNamesEnable bool) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *utils.ConfigurationOptions) error {
 	name := managed.ControllerName(v1alpha1.NodePoolGroupKind)
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -65,12 +65,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, c
 				kube:                 mgr.GetClient(),
 				usage:                resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:                  l,
-				isUniqueNamesEnabled: uniqueNamesEnable}),
+				isUniqueNamesEnabled: opts.GetIsUniqueNamesEnabled()}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
-			managed.WithPollInterval(poll),
-			managed.WithTimeout(timeout),
-			managed.WithCreationGracePeriod(creationGracePeriod),
+			managed.WithPollInterval(opts.GetPollInterval()),
+			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(l.WithValues("controller", name)),
 			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
 }

--- a/internal/mock/clients/compute/datacenter/datacenter.go
+++ b/internal/mock/clients/compute/datacenter/datacenter.go
@@ -36,18 +36,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CheckDuplicateDatacenter mocks base method.
-func (m *MockClient) CheckDuplicateDatacenter(ctx context.Context, datacenterName, loacation string) (*ionoscloud.Datacenter, error) {
+func (m *MockClient) CheckDuplicateDatacenter(ctx context.Context, datacenterName, location string) (*ionoscloud.Datacenter, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckDuplicateDatacenter", ctx, datacenterName, loacation)
+	ret := m.ctrl.Call(m, "CheckDuplicateDatacenter", ctx, datacenterName, location)
 	ret0, _ := ret[0].(*ionoscloud.Datacenter)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckDuplicateDatacenter indicates an expected call of CheckDuplicateDatacenter.
-func (mr *MockClientMockRecorder) CheckDuplicateDatacenter(ctx, datacenterName, loacation interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CheckDuplicateDatacenter(ctx, datacenterName, location interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateDatacenter", reflect.TypeOf((*MockClient)(nil).CheckDuplicateDatacenter), ctx, datacenterName, loacation)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateDatacenter", reflect.TypeOf((*MockClient)(nil).CheckDuplicateDatacenter), ctx, datacenterName, location)
 }
 
 // CreateDatacenter mocks base method.

--- a/internal/mock/clients/compute/datacenter/datacenter.go
+++ b/internal/mock/clients/compute/datacenter/datacenter.go
@@ -35,6 +35,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CheckDuplicateDatacenter mocks base method.
+func (m *MockClient) CheckDuplicateDatacenter(ctx context.Context, datacenterName, loacation string) (*ionoscloud.Datacenter, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckDuplicateDatacenter", ctx, datacenterName, loacation)
+	ret0, _ := ret[0].(*ionoscloud.Datacenter)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckDuplicateDatacenter indicates an expected call of CheckDuplicateDatacenter.
+func (mr *MockClientMockRecorder) CheckDuplicateDatacenter(ctx, datacenterName, loacation interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateDatacenter", reflect.TypeOf((*MockClient)(nil).CheckDuplicateDatacenter), ctx, datacenterName, loacation)
+}
+
 // CreateDatacenter mocks base method.
 func (m *MockClient) CreateDatacenter(ctx context.Context, datacenter ionoscloud.Datacenter) (ionoscloud.Datacenter, *ionoscloud.APIResponse, error) {
 	m.ctrl.T.Helper()
@@ -109,6 +124,21 @@ func (m *MockClient) GetDatacenter(ctx context.Context, datacenterID string) (io
 func (mr *MockClientMockRecorder) GetDatacenter(ctx, datacenterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatacenter", reflect.TypeOf((*MockClient)(nil).GetDatacenter), ctx, datacenterID)
+}
+
+// GetDatacenterID mocks base method.
+func (m *MockClient) GetDatacenterID(datacenter *ionoscloud.Datacenter) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDatacenterID", datacenter)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDatacenterID indicates an expected call of GetDatacenterID.
+func (mr *MockClientMockRecorder) GetDatacenterID(datacenter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatacenterID", reflect.TypeOf((*MockClient)(nil).GetDatacenterID), datacenter)
 }
 
 // UpdateDatacenter mocks base method.

--- a/internal/mock/clients/compute/ipblock/ipblock.go
+++ b/internal/mock/clients/compute/ipblock/ipblock.go
@@ -35,6 +35,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CheckDuplicateIPBlock mocks base method.
+func (m *MockClient) CheckDuplicateIPBlock(ctx context.Context, ipBlockName, location string) (*ionoscloud.IpBlock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckDuplicateIPBlock", ctx, ipBlockName, location)
+	ret0, _ := ret[0].(*ionoscloud.IpBlock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckDuplicateIPBlock indicates an expected call of CheckDuplicateIPBlock.
+func (mr *MockClientMockRecorder) CheckDuplicateIPBlock(ctx, ipBlockName, location interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateIPBlock", reflect.TypeOf((*MockClient)(nil).CheckDuplicateIPBlock), ctx, ipBlockName, location)
+}
+
 // CreateIPBlock mocks base method.
 func (m *MockClient) CreateIPBlock(ctx context.Context, ipBlock ionoscloud.IpBlock) (ionoscloud.IpBlock, *ionoscloud.APIResponse, error) {
 	m.ctrl.T.Helper()
@@ -94,6 +109,21 @@ func (m *MockClient) GetIPBlock(ctx context.Context, ipBlockID string) (ionosclo
 func (mr *MockClientMockRecorder) GetIPBlock(ctx, ipBlockID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPBlock", reflect.TypeOf((*MockClient)(nil).GetIPBlock), ctx, ipBlockID)
+}
+
+// GetIPBlockID mocks base method.
+func (m *MockClient) GetIPBlockID(ipBlock *ionoscloud.IpBlock) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIPBlockID", ipBlock)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetIPBlockID indicates an expected call of GetIPBlockID.
+func (mr *MockClientMockRecorder) GetIPBlockID(ipBlock interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIPBlockID", reflect.TypeOf((*MockClient)(nil).GetIPBlockID), ipBlock)
 }
 
 // GetIPs mocks base method.

--- a/internal/mock/clients/k8s/k8scluster/cluster.go
+++ b/internal/mock/clients/k8s/k8scluster/cluster.go
@@ -35,6 +35,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CheckDuplicateK8sCluster mocks base method.
+func (m *MockClient) CheckDuplicateK8sCluster(ctx context.Context, clusterName string) (*ionoscloud.KubernetesCluster, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckDuplicateK8sCluster", ctx, clusterName)
+	ret0, _ := ret[0].(*ionoscloud.KubernetesCluster)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckDuplicateK8sCluster indicates an expected call of CheckDuplicateK8sCluster.
+func (mr *MockClientMockRecorder) CheckDuplicateK8sCluster(ctx, clusterName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateK8sCluster", reflect.TypeOf((*MockClient)(nil).CheckDuplicateK8sCluster), ctx, clusterName)
+}
+
 // CreateK8sCluster mocks base method.
 func (m *MockClient) CreateK8sCluster(ctx context.Context, cluster ionoscloud.KubernetesClusterForPost) (ionoscloud.KubernetesCluster, *ionoscloud.APIResponse, error) {
 	m.ctrl.T.Helper()
@@ -94,6 +109,21 @@ func (m *MockClient) GetK8sCluster(ctx context.Context, clusterID string) (ionos
 func (mr *MockClientMockRecorder) GetK8sCluster(ctx, clusterID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetK8sCluster", reflect.TypeOf((*MockClient)(nil).GetK8sCluster), ctx, clusterID)
+}
+
+// GetK8sClusterID mocks base method.
+func (m *MockClient) GetK8sClusterID(cluster *ionoscloud.KubernetesCluster) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetK8sClusterID", cluster)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetK8sClusterID indicates an expected call of GetK8sClusterID.
+func (mr *MockClientMockRecorder) GetK8sClusterID(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetK8sClusterID", reflect.TypeOf((*MockClient)(nil).GetK8sClusterID), cluster)
 }
 
 // GetKubeConfig mocks base method.

--- a/internal/mock/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/mock/clients/k8s/k8snodepool/nodepool.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	v1alpha1 "github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/k8s/v1alpha1"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
@@ -36,18 +37,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CheckDuplicateK8sNodePool mocks base method.
-func (m *MockClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodepoolName string) (*ionoscloud.KubernetesNodePool, error) {
+func (m *MockClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodepoolName string, cr *v1alpha1.NodePool) (*ionoscloud.KubernetesNodePool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckDuplicateK8sNodePool", ctx, clusterID, nodepoolName)
+	ret := m.ctrl.Call(m, "CheckDuplicateK8sNodePool", ctx, clusterID, nodepoolName, cr)
 	ret0, _ := ret[0].(*ionoscloud.KubernetesNodePool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckDuplicateK8sNodePool indicates an expected call of CheckDuplicateK8sNodePool.
-func (mr *MockClientMockRecorder) CheckDuplicateK8sNodePool(ctx, clusterID, nodepoolName interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CheckDuplicateK8sNodePool(ctx, clusterID, nodepoolName, cr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateK8sNodePool", reflect.TypeOf((*MockClient)(nil).CheckDuplicateK8sNodePool), ctx, clusterID, nodepoolName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateK8sNodePool", reflect.TypeOf((*MockClient)(nil).CheckDuplicateK8sNodePool), ctx, clusterID, nodepoolName, cr)
 }
 
 // CreateK8sNodePool mocks base method.

--- a/internal/mock/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/mock/clients/k8s/k8snodepool/nodepool.go
@@ -35,6 +35,21 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CheckDuplicateK8sNodePool mocks base method.
+func (m *MockClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodepoolName string) (*ionoscloud.KubernetesNodePool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckDuplicateK8sNodePool", ctx, clusterID, nodepoolName)
+	ret0, _ := ret[0].(*ionoscloud.KubernetesNodePool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckDuplicateK8sNodePool indicates an expected call of CheckDuplicateK8sNodePool.
+func (mr *MockClientMockRecorder) CheckDuplicateK8sNodePool(ctx, clusterID, nodepoolName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateK8sNodePool", reflect.TypeOf((*MockClient)(nil).CheckDuplicateK8sNodePool), ctx, clusterID, nodepoolName)
+}
+
 // CreateK8sNodePool mocks base method.
 func (m *MockClient) CreateK8sNodePool(ctx context.Context, clusterID string, nodepool ionoscloud.KubernetesNodePoolForPost) (ionoscloud.KubernetesNodePool, *ionoscloud.APIResponse, error) {
 	m.ctrl.T.Helper()
@@ -94,6 +109,21 @@ func (m *MockClient) GetK8sNodePool(ctx context.Context, clusterID, nodepoolID s
 func (mr *MockClientMockRecorder) GetK8sNodePool(ctx, clusterID, nodepoolID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetK8sNodePool", reflect.TypeOf((*MockClient)(nil).GetK8sNodePool), ctx, clusterID, nodepoolID)
+}
+
+// GetK8sNodePoolID mocks base method.
+func (m *MockClient) GetK8sNodePoolID(nodepool *ionoscloud.KubernetesNodePool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetK8sNodePoolID", nodepool)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetK8sNodePoolID indicates an expected call of GetK8sNodePoolID.
+func (mr *MockClientMockRecorder) GetK8sNodePoolID(nodepool interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetK8sNodePoolID", reflect.TypeOf((*MockClient)(nil).GetK8sNodePoolID), nodepool)
 }
 
 // UpdateK8sNodePool mocks base method.

--- a/internal/mock/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/mock/clients/k8s/k8snodepool/nodepool.go
@@ -37,18 +37,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CheckDuplicateK8sNodePool mocks base method.
-func (m *MockClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodepoolName string, cr *v1alpha1.NodePool) (*ionoscloud.KubernetesNodePool, error) {
+func (m *MockClient) CheckDuplicateK8sNodePool(ctx context.Context, clusterID, nodePoolName string, cr *v1alpha1.NodePool) (*ionoscloud.KubernetesNodePool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckDuplicateK8sNodePool", ctx, clusterID, nodepoolName, cr)
+	ret := m.ctrl.Call(m, "CheckDuplicateK8sNodePool", ctx, clusterID, nodePoolName, cr)
 	ret0, _ := ret[0].(*ionoscloud.KubernetesNodePool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckDuplicateK8sNodePool indicates an expected call of CheckDuplicateK8sNodePool.
-func (mr *MockClientMockRecorder) CheckDuplicateK8sNodePool(ctx, clusterID, nodepoolName, cr interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) CheckDuplicateK8sNodePool(ctx, clusterID, nodePoolName, cr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateK8sNodePool", reflect.TypeOf((*MockClient)(nil).CheckDuplicateK8sNodePool), ctx, clusterID, nodepoolName, cr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicateK8sNodePool", reflect.TypeOf((*MockClient)(nil).CheckDuplicateK8sNodePool), ctx, clusterID, nodePoolName, cr)
 }
 
 // CreateK8sNodePool mocks base method.

--- a/internal/utils/configuration.go
+++ b/internal/utils/configuration.go
@@ -1,0 +1,54 @@
+package utils
+
+import "time"
+
+// ConfigurationOptions are options used in setting the provider
+// and the controllers of the provider.
+type ConfigurationOptions struct {
+	PollInterval         time.Duration
+	CreationGracePeriod  time.Duration
+	Timeout              time.Duration
+	IsUniqueNamesEnabled bool
+}
+
+// NewConfigurationOptions sets fields for ConfigurationOptions and return a new ConfigurationOptions
+func NewConfigurationOptions(poll, createGracePeriod, timeout time.Duration, uniqueNamesEnable bool) *ConfigurationOptions {
+	return &ConfigurationOptions{
+		PollInterval:         poll,
+		CreationGracePeriod:  createGracePeriod,
+		Timeout:              timeout,
+		IsUniqueNamesEnabled: uniqueNamesEnable,
+	}
+}
+
+// GetPollInterval returns the value for the PollInterval option
+func (o *ConfigurationOptions) GetPollInterval() time.Duration {
+	if o == nil {
+		return 0
+	}
+	return o.PollInterval
+}
+
+// GetCreationGracePeriod returns the value for the CreationGracePeriod option
+func (o *ConfigurationOptions) GetCreationGracePeriod() time.Duration {
+	if o == nil {
+		return 0
+	}
+	return o.CreationGracePeriod
+}
+
+// GetTimeout returns the value for the Timeout option
+func (o *ConfigurationOptions) GetTimeout() time.Duration {
+	if o == nil {
+		return 0
+	}
+	return o.Timeout
+}
+
+// GetIsUniqueNamesEnabled returns the value for the IsUniqueNamesEnabled option
+func (o *ConfigurationOptions) GetIsUniqueNamesEnabled() bool {
+	if o == nil {
+		return false
+	}
+	return o.IsUniqueNamesEnabled
+}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds `--unique-names` option, to support name uniqueness for IONOS Cloud Resources.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [x] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [x] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [x] Check Sonar Cloud Scan
- [x] Update Github or Jira Issue
