### PR TITLE
fix: remove `mac` field from Nic spec

### DIFF
--- a/apis/compute/v1alpha1/nic_types.go
+++ b/apis/compute/v1alpha1/nic_types.go
@@ -51,10 +51,6 @@ type NicParameters struct {
 	//
 	// +kubebuilder:validation:Optional
 	Name string `json:"name,omitempty"`
-	// The MAC address of the NIC.
-	//
-	// +kubebuilder:validation:Optional
-	Mac string `json:"mac,omitempty"`
 	// Collection of IP addresses, assigned to the NIC.
 	// Explicitly assigned public IPs need to come from reserved IP blocks.
 	// Passing value null or empty array will assign an IP address automatically.
@@ -107,6 +103,7 @@ type NicObservation struct {
 	VolumeID string   `json:"volumeId,omitempty"`
 	IPs      []string `json:"ips,omitempty"`
 	State    string   `json:"state,omitempty"`
+	Mac      string   `json:"mac,omitempty"`
 }
 
 // A NicSpec defines the desired state of a Nic.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [1.0.0] (July 2022)
 
+- **Features**:
+    - Added `--unique-names` option support for name uniqueness for IONOS Cloud resources
 - **Fixes**:
     - Removed read-only field `mac` from `Nic` Managed Resource:
         - New field: `status.atProvider.mac`;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.0.0] (July 2022)
+
+- **Fixes**:
+    - Removed read-only field `mac` from `Nic` Managed Resource:
+        - New field: `status.atProvider.mac`;
+    - Updated User Agent for Crossplane Provider for IONOS Cloud to contain provider version;
+- **Documentation**:
+    - Updated documentation with the `--unique-names` option support.
+
 ## [1.0.0-beta.5] (July 2022)
 
 - **Features**:

--- a/docs/api/compute-engine/nic.md
+++ b/docs/api/compute-engine/nic.md
@@ -73,6 +73,13 @@ _Note_: The command should be run from the root of the `crossplane-provider-iono
 
 In order to configure the IONOS Cloud Resource, the user can set the `spec.forProvider` fields into the specification file for the resource instance. The required fields that need to be set can be found [here](#required-properties). Following, there is a list of all the properties:
 
+* `dhcp` (boolean)
+	* description: Indicates if the NIC will reserve an IP using DHCP.
+* `firewallActive` (boolean)
+	* description: Activate or deactivate the firewall. By default, an active firewall without any defined rules will block all incoming network traffic except for the firewall rules that explicitly allows certain protocols, IP addresses and ports.
+* `firewallType` (string)
+	* description: The type of firewall rules that will be allowed on the NIC. If not specified, the default INGRESS value is used.
+	* possible values: "BIDIRECTIONAL";"EGRESS";"INGRESS"
 * `ipsConfigs` (object)
 	* description: Collection of IP addresses, assigned to the NIC. Explicitly assigned public IPs need to come from reserved IP blocks. Passing value null or empty array will assign an IP address automatically. The IPs can be set directly or using reference to the existing IPBlocks and indexes. If no indexes are set, all IPs from the corresponding IPBlock will be assigned. All IPs set on the Nic will be displayed on the status's ips field.
 	* properties:
@@ -100,45 +107,9 @@ In order to configure the IONOS Cloud Resource, the user can set the `spec.forPr
 							* description: MatchLabels ensures an object with matching labels is selected.
 				* `indexes` (array)
 					* description: Indexes are referring to the IPs indexes retrieved from the IPBlock. Indexes are starting from 0. If no index is set, all IPs from the corresponding IPBlock will be assigned.
-* `mac` (string)
-	* description: The MAC address of the NIC.
-* `name` (string)
-	* description: The name of the  resource.
-* `datacenterConfig` (object)
-	* description: DatacenterConfig contains information about the datacenter resource on which the nic will be created.
-	* properties:
-		* `datacenterIdSelector` (object)
-			* description: DatacenterIDSelector selects reference to a Datacenter to retrieve its DatacenterID.
-			* properties:
-				* `matchControllerRef` (boolean)
-					* description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.
-				* `matchLabels` (object)
-					* description: MatchLabels ensures an object with matching labels is selected.
-		* `datacenterId` (string)
-			* description: DatacenterID is the ID of the Datacenter on which the resource will be created. It needs to be provided via directly or via reference.
-			* format: uuid
-		* `datacenterIdRef` (object)
-			* description: DatacenterIDRef references to a Datacenter to retrieve its ID.
-			* properties:
-				* `name` (string)
-					* description: Name of the referenced object.
-			* required properties:
-				* `name`
-* `firewallActive` (boolean)
-	* description: Activate or deactivate the firewall. By default, an active firewall without any defined rules will block all incoming network traffic except for the firewall rules that explicitly allows certain protocols, IP addresses and ports.
-* `firewallType` (string)
-	* description: The type of firewall rules that will be allowed on the NIC. If not specified, the default INGRESS value is used.
-	* possible values: "BIDIRECTIONAL";"EGRESS";"INGRESS"
 * `lanConfig` (object)
 	* description: LanConfig contains information about the lan resource on which the nic will be on.
 	* properties:
-		* `lanIdRef` (object)
-			* description: LanIDRef references to a Lan to retrieve its ID.
-			* properties:
-				* `name` (string)
-					* description: Name of the referenced object.
-			* required properties:
-				* `name`
 		* `lanIdSelector` (object)
 			* description: LanIDSelector selects reference to a Lan to retrieve its LanID.
 			* properties:
@@ -148,6 +119,15 @@ In order to configure the IONOS Cloud Resource, the user can set the `spec.forPr
 					* description: MatchLabels ensures an object with matching labels is selected.
 		* `lanId` (string)
 			* description: LanID is the ID of the Lan on which the resource will be created. It needs to be provided via directly or via reference.
+		* `lanIdRef` (object)
+			* description: LanIDRef references to a Lan to retrieve its ID.
+			* properties:
+				* `name` (string)
+					* description: Name of the referenced object.
+			* required properties:
+				* `name`
+* `name` (string)
+	* description: The name of the  resource.
 * `serverConfig` (object)
 	* description: ServerConfig contains information about the server resource on which the nic will be created.
 	* properties:
@@ -168,8 +148,26 @@ In order to configure the IONOS Cloud Resource, the user can set the `spec.forPr
 					* description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.
 				* `matchLabels` (object)
 					* description: MatchLabels ensures an object with matching labels is selected.
-* `dhcp` (boolean)
-	* description: Indicates if the NIC will reserve an IP using DHCP.
+* `datacenterConfig` (object)
+	* description: DatacenterConfig contains information about the datacenter resource on which the nic will be created.
+	* properties:
+		* `datacenterId` (string)
+			* description: DatacenterID is the ID of the Datacenter on which the resource will be created. It needs to be provided via directly or via reference.
+			* format: uuid
+		* `datacenterIdRef` (object)
+			* description: DatacenterIDRef references to a Datacenter to retrieve its ID.
+			* properties:
+				* `name` (string)
+					* description: Name of the referenced object.
+			* required properties:
+				* `name`
+		* `datacenterIdSelector` (object)
+			* description: DatacenterIDSelector selects reference to a Datacenter to retrieve its DatacenterID.
+			* properties:
+				* `matchLabels` (object)
+					* description: MatchLabels ensures an object with matching labels is selected.
+				* `matchControllerRef` (boolean)
+					* description: MatchControllerRef ensures an object with the same controller reference as the selecting object is selected.
 
 ### Required Properties
 

--- a/examples/ionoscloud/compute/nic.yaml
+++ b/examples/ionoscloud/compute/nic.yaml
@@ -23,7 +23,6 @@ spec:
           indexes: [ 1 ]
         - ipBlockIdRef:
             name: example
-    #    mac:
     #    firewallActive: true
     firewallType: INGRESS
     datacenterConfig:

--- a/internal/clients/compute/nic/nic.go
+++ b/internal/clients/compute/nic/nic.go
@@ -83,9 +83,6 @@ func GenerateCreateNicInput(cr *v1alpha1.Nic, ips []string) (*sdkgo.Nic, error) 
 	if !utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.Name)) {
 		instanceCreateInput.Properties.SetName(cr.Spec.ForProvider.Name)
 	}
-	if !utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.Mac)) {
-		instanceCreateInput.Properties.SetMac(cr.Spec.ForProvider.Mac)
-	}
 	if !utils.IsEmptyValue(reflect.ValueOf(ips)) {
 		instanceCreateInput.Properties.SetIps(ips)
 	}
@@ -108,9 +105,6 @@ func GenerateUpdateNicInput(cr *v1alpha1.Nic, ips []string) (*sdkgo.NicPropertie
 	}
 	if !utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.Name)) {
 		instanceUpdateInput.SetName(cr.Spec.ForProvider.Name)
-	}
-	if !utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.Mac)) {
-		instanceUpdateInput.SetMac(cr.Spec.ForProvider.Mac)
 	}
 	if !utils.IsEmptyValue(reflect.ValueOf(ips)) {
 		instanceUpdateInput.SetIps(ips)

--- a/internal/controller/compute/nic/nic.go
+++ b/internal/controller/compute/nic/nic.go
@@ -137,6 +137,9 @@ func (c *externalNic) Observe(ctx context.Context, mg resource.Managed) (managed
 		if instance.Properties.HasIps() {
 			cr.Status.AtProvider.IPs = *instance.Properties.Ips
 		}
+		if instance.Properties.HasMac() {
+			cr.Status.AtProvider.Mac = *instance.Properties.Mac
+		}
 	}
 	c.log.Debug(fmt.Sprintf("Observing state: %v", cr.Status.AtProvider.State))
 	// Set Ready condition based on State

--- a/package/crds/compute.ionoscloud.crossplane.io_nics.yaml
+++ b/package/crds/compute.ionoscloud.crossplane.io_nics.yaml
@@ -242,9 +242,6 @@ spec:
                             type: object
                         type: object
                     type: object
-                  mac:
-                    description: The MAC address of the NIC.
-                    type: string
                   name:
                     description: The name of the  resource.
                     type: string
@@ -345,6 +342,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  mac:
+                    type: string
                   nicId:
                     type: string
                   state:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds update on `mac` field from Nic Compute Resource. The field is removed from spec as it is a read-only property and it is added to the status of the resource.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [x] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [x] Add or update Documentation using `make docs.update` (if applicable)
- [x] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [x] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
