### PR TITLE
fix: update name when upstream name is nil

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [1.0.0] (July 2022)
 
 - **Features**:
-    - Added `--unique-names` option support for name uniqueness for IONOS Cloud resources
+    - Added `--unique-names` option support for name uniqueness for IONOS Cloud resources;
+    - Added check for `spec.forProvider.name` field on `NodePool` K8s Managed Resource - for reconciliation loops;
+    - Added check for resources to be updated when name from IONOS Cloud is nil and `spec.forProvider.name` is not empty;
 - **Fixes**:
-    - Removed read-only field `mac` from `Nic` Managed Resource:
+    - Removed read-only field `mac` from `Nic` Compute Managed Resource:
         - New field: `status.atProvider.mac`;
     - Updated User Agent for Crossplane Provider for IONOS Cloud to contain provider version;
 - **Documentation**:

--- a/internal/clients/alb/applicationloadbalancer/applicationloadbalancer.go
+++ b/internal/clients/alb/applicationloadbalancer/applicationloadbalancer.go
@@ -172,6 +172,8 @@ func IsApplicationLoadBalancerUpToDate(cr *v1alpha1.ApplicationLoadBalancer, app
 		return true
 	case applicationloadbalancer.Properties.Name != nil && *applicationloadbalancer.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case applicationloadbalancer.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case applicationloadbalancer.Properties.ListenerLan != nil && *applicationloadbalancer.Properties.ListenerLan != listenerLan:
 		return false
 	case applicationloadbalancer.Properties.TargetLan != nil && *applicationloadbalancer.Properties.TargetLan != targetLan:

--- a/internal/clients/alb/forwardingrule/forwardingrule.go
+++ b/internal/clients/alb/forwardingrule/forwardingrule.go
@@ -165,6 +165,8 @@ func IsForwardingRuleUpToDate(cr *v1alpha1.ForwardingRule, forwardingRule sdkgo.
 		return true
 	case forwardingRule.Properties.Name != nil && *forwardingRule.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case forwardingRule.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case forwardingRule.Properties.Protocol != nil && *forwardingRule.Properties.Protocol != cr.Spec.ForProvider.Protocol:
 		return false
 	case forwardingRule.Properties.ListenerIp != nil && *forwardingRule.Properties.ListenerIp != listenerIP:

--- a/internal/clients/alb/targetgroup/targetgroup.go
+++ b/internal/clients/alb/targetgroup/targetgroup.go
@@ -194,6 +194,8 @@ func IsTargetGroupUpToDate(cr *v1alpha1.TargetGroup, targetGroup sdkgo.TargetGro
 		return true
 	case targetGroup.Properties.Name != nil && *targetGroup.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case targetGroup.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case targetGroup.Properties.Protocol != nil && *targetGroup.Properties.Protocol != cr.Spec.ForProvider.Protocol:
 		return false
 	case targetGroup.Properties.Algorithm != nil && *targetGroup.Properties.Algorithm != cr.Spec.ForProvider.Algorithm:

--- a/internal/clients/backup/backupunit/backupunit.go
+++ b/internal/clients/backup/backupunit/backupunit.go
@@ -165,6 +165,8 @@ func IsBackupUnitUpToDate(cr *v1alpha1.BackupUnit, backupUnit sdkgo.BackupUnit) 
 		return true
 	case backupUnit.Properties.Name != nil && *backupUnit.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case backupUnit.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case backupUnit.Properties.Email != nil && *backupUnit.Properties.Email != cr.Spec.ForProvider.Email:
 		return false
 	case cr.Spec.ForProvider.Password != oldPassword:

--- a/internal/clients/compute/datacenter/datacenter.go
+++ b/internal/clients/compute/datacenter/datacenter.go
@@ -152,6 +152,8 @@ func IsDatacenterUpToDate(cr *v1alpha1.Datacenter, datacenter sdkgo.Datacenter) 
 		return true
 	case datacenter.Properties.Name != nil && *datacenter.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case datacenter.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case datacenter.Properties.Description != nil && *datacenter.Properties.Description != cr.Spec.ForProvider.Description:
 		return false
 	default:

--- a/internal/clients/compute/firewallrule/firewallrule.go
+++ b/internal/clients/compute/firewallrule/firewallrule.go
@@ -186,6 +186,8 @@ func IsFirewallRuleUpToDate(cr *v1alpha1.FirewallRule, firewallRule sdkgo.Firewa
 		return true
 	case firewallRule.Properties.Name != nil && *firewallRule.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case firewallRule.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case firewallRule.Properties.SourceMac != nil && *firewallRule.Properties.SourceMac != cr.Spec.ForProvider.SourceMac:
 		return false
 	case firewallRule.Properties.SourceIp != nil && *firewallRule.Properties.SourceIp != sourceIP:

--- a/internal/clients/compute/ipblock/ipblock.go
+++ b/internal/clients/compute/ipblock/ipblock.go
@@ -175,6 +175,8 @@ func IsIPBlockUpToDate(cr *v1alpha1.IPBlock, ipBlock sdkgo.IpBlock) bool { // no
 		return true
 	case ipBlock.Properties.Name != nil && *ipBlock.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case ipBlock.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	default:
 		return true
 	}

--- a/internal/clients/compute/lan/lan.go
+++ b/internal/clients/compute/lan/lan.go
@@ -150,6 +150,8 @@ func IsLanUpToDate(cr *v1alpha1.Lan, lan sdkgo.Lan) bool { // nolint:gocyclo
 		return true
 	case lan.Properties.Name != nil && *lan.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case lan.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case lan.Properties.Public != nil && *lan.Properties.Public != cr.Spec.ForProvider.Public:
 		return false
 	case lan.Properties.Pcc != nil && *lan.Properties.Pcc != cr.Spec.ForProvider.Pcc:

--- a/internal/clients/compute/nic/nic.go
+++ b/internal/clients/compute/nic/nic.go
@@ -169,6 +169,8 @@ func IsNicUpToDate(cr *v1alpha1.Nic, nic sdkgo.Nic, ips []string, oldIps []strin
 		return true
 	case nic.Properties.Name != nil && *nic.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case nic.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case nic.Properties.Dhcp != nil && *nic.Properties.Dhcp != cr.Spec.ForProvider.Dhcp:
 		return false
 	case nic.Properties.FirewallActive != nil && *nic.Properties.FirewallActive != cr.Spec.ForProvider.FirewallActive:

--- a/internal/clients/compute/server/server.go
+++ b/internal/clients/compute/server/server.go
@@ -347,6 +347,8 @@ func IsCubeServerUpToDate(cr *v1alpha1.CubeServer, server sdkgo.Server) bool { /
 		return true
 	case server.Properties.Name != nil && *server.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case server.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case server.Properties.BootVolume != nil && *server.Properties.BootVolume.Id != cr.Status.AtProvider.VolumeID:
 		return false
 	case cr.Status.AtProvider.VolumeID != "" && !server.Properties.HasBootVolume():

--- a/internal/clients/compute/server/server.go
+++ b/internal/clients/compute/server/server.go
@@ -218,6 +218,8 @@ func IsServerUpToDate(cr *v1alpha1.Server, server sdkgo.Server) bool { // nolint
 		return false
 	case server.Properties.Name != nil && cr.Spec.ForProvider.Name != *server.Properties.Name:
 		return false
+	case server.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case server.Properties.Cores != nil && cr.Spec.ForProvider.Cores != *server.Properties.Cores:
 		return false
 	case server.Properties.Ram != nil && cr.Spec.ForProvider.RAM != *server.Properties.Ram:

--- a/internal/clients/compute/volume/volume.go
+++ b/internal/clients/compute/volume/volume.go
@@ -194,6 +194,8 @@ func IsVolumeUpToDate(cr *v1alpha1.Volume, volume *sdkgo.Volume) bool { // nolin
 		return true
 	case volume.Properties.Name != nil && *volume.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case volume.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case volume.Properties.Size != nil && *volume.Properties.Size != cr.Spec.ForProvider.Size:
 		return false
 	case volume.Properties.CpuHotPlug != nil && *volume.Properties.CpuHotPlug != cr.Spec.ForProvider.CPUHotPlug:

--- a/internal/clients/dbaas/postgrescluster/postgrescluster.go
+++ b/internal/clients/dbaas/postgrescluster/postgrescluster.go
@@ -198,6 +198,8 @@ func IsClusterUpToDate(cr *v1alpha1.PostgresCluster, clusterResponse ionoscloud.
 		return true
 	case clusterResponse.Properties.DisplayName != nil && *clusterResponse.Properties.DisplayName != cr.Spec.ForProvider.DisplayName:
 		return false
+	case clusterResponse.Properties.DisplayName == nil && cr.Spec.ForProvider.DisplayName != "":
+		return false
 	case clusterResponse.Properties.PostgresVersion != nil && *clusterResponse.Properties.PostgresVersion != cr.Spec.ForProvider.PostgresVersion:
 		return false
 	case clusterResponse.Properties.Instances != nil && *clusterResponse.Properties.Instances != cr.Spec.ForProvider.Instances:

--- a/internal/clients/k8s/k8scluster/cluster.go
+++ b/internal/clients/k8s/k8scluster/cluster.go
@@ -224,6 +224,8 @@ func IsK8sClusterUpToDate(cr *v1alpha1.Cluster, cluster sdkgo.KubernetesCluster)
 		return true
 	case cluster.Properties.Name != nil && *cluster.Properties.Name != cr.Spec.ForProvider.Name:
 		return false
+	case cluster.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case cluster.Properties.K8sVersion != nil && *cluster.Properties.K8sVersion != cr.Spec.ForProvider.K8sVersion:
 		return false
 	case cluster.Properties.S3Buckets != nil && !isEqS3Buckets(cr.Spec.ForProvider.S3Buckets, *cluster.Properties.S3Buckets):

--- a/internal/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/clients/k8s/k8snodepool/nodepool.go
@@ -272,6 +272,10 @@ func IsK8sNodePoolUpToDate(cr *v1alpha1.NodePool, nodepool sdkgo.KubernetesNodeP
 		return false
 	case nodepool.Metadata != nil && nodepool.Metadata.State != nil && (*nodepool.Metadata.State == "BUSY" || *nodepool.Metadata.State == "DEPLOYING"):
 		return true
+	case nodepool.Properties.Name != nil && *nodepool.Properties.Name != cr.Spec.ForProvider.Name:
+		return false
+	case nodepool.Properties.Name == nil && cr.Spec.ForProvider.Name != "":
+		return false
 	case nodepool.Properties.K8sVersion != nil && *nodepool.Properties.K8sVersion != cr.Spec.ForProvider.K8sVersion:
 		return false
 	case nodepool.Properties.NodeCount != nil && *nodepool.Properties.NodeCount != cr.Spec.ForProvider.NodeCount:

--- a/internal/controller/k8s/k8snodepool/nodepool_test.go
+++ b/internal/controller/k8s/k8snodepool/nodepool_test.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	testClusterID  = "cluster-id"
-	testNodePoolID = "nodepool-id"
-	testIPBlockID  = "ipblock-id"
+	testClusterID    = "cluster-id"
+	testNodePoolID   = "nodepool-id"
+	testIPBlockID    = "ipblock-id"
+	testNodePoolName = "node-pool-name"
 )
 
 func TestExternalNodePoolObserve(t *testing.T) {
@@ -36,6 +37,7 @@ func TestExternalNodePoolObserve(t *testing.T) {
 	basicObserveNodePool := &v1alpha1.NodePool{
 		Spec: v1alpha1.NodePoolSpec{
 			ForProvider: v1alpha1.NodePoolParameters{
+				Name:          testNodePoolName,
 				DatacenterCfg: v1alpha1.DatacenterConfig{DatacenterID: "12345"},
 				ClusterCfg: v1alpha1.ClusterConfig{
 					ClusterID: testClusterID,
@@ -86,7 +88,7 @@ func TestExternalNodePoolObserve(t *testing.T) {
 						GetK8sNodePool(context.Background(), testClusterID, testNodePoolID).
 						Return(ionoscloud.KubernetesNodePool{
 							Properties: &ionoscloud.KubernetesNodePoolProperties{
-								Name: ionoscloud.PtrString("node-pool-name"),
+								Name: ionoscloud.PtrString(testNodePoolName),
 							},
 						}, nil, nil)
 				},
@@ -153,7 +155,7 @@ func TestExternalNodePoolObserve(t *testing.T) {
 						GetK8sNodePool(context.Background(), testClusterID, testNodePoolID).
 						Return(ionoscloud.KubernetesNodePool{
 							Properties: &ionoscloud.KubernetesNodePoolProperties{
-								Name: ionoscloud.PtrString("node-pool-name"),
+								Name: ionoscloud.PtrString(testNodePoolName),
 							},
 						}, nil, nil)
 				},
@@ -176,7 +178,7 @@ func TestExternalNodePoolObserve(t *testing.T) {
 						GetK8sNodePool(context.Background(), testClusterID, testNodePoolID).
 						Return(ionoscloud.KubernetesNodePool{
 							Properties: &ionoscloud.KubernetesNodePoolProperties{
-								Name:      ionoscloud.PtrString("node-pool-name"),
+								Name:      ionoscloud.PtrString(testNodePoolName),
 								NodeCount: ionoscloud.PtrInt32(2),
 							},
 						}, nil, nil)
@@ -200,7 +202,7 @@ func TestExternalNodePoolObserve(t *testing.T) {
 						GetK8sNodePool(context.Background(), testClusterID, testNodePoolID).
 						Return(ionoscloud.KubernetesNodePool{
 							Properties: &ionoscloud.KubernetesNodePoolProperties{
-								Name: ionoscloud.PtrString("node-pool-name"),
+								Name: ionoscloud.PtrString(testNodePoolName),
 								Labels: &map[string]string{
 									"some": "old-label",
 								},
@@ -232,7 +234,7 @@ func TestExternalNodePoolObserve(t *testing.T) {
 						GetK8sNodePool(context.Background(), testClusterID, testNodePoolID).
 						Return(ionoscloud.KubernetesNodePool{
 							Properties: &ionoscloud.KubernetesNodePoolProperties{
-								Name: ionoscloud.PtrString("node-pool-name"),
+								Name: ionoscloud.PtrString(testNodePoolName),
 								Annotations: &map[string]string{
 									"some": "old-annotation",
 								},
@@ -299,7 +301,7 @@ func TestExternalNodePoolDelete(t *testing.T) {
 	basicDeleteNodepool := &v1alpha1.NodePool{
 		Spec: v1alpha1.NodePoolSpec{
 			ForProvider: v1alpha1.NodePoolParameters{
-				Name: "node-pool-name",
+				Name: testNodePoolName,
 				ClusterCfg: v1alpha1.ClusterConfig{
 					ClusterID: testClusterID,
 				},
@@ -855,7 +857,7 @@ func TestExternalNodePoolUpdate(t *testing.T) {
 	basicUpdateNodePool := &v1alpha1.NodePool{
 		Spec: v1alpha1.NodePoolSpec{
 			ForProvider: v1alpha1.NodePoolParameters{
-				Name: "node-pool-name",
+				Name: testNodePoolName,
 				ClusterCfg: v1alpha1.ClusterConfig{
 					ClusterID: testClusterID,
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:
- check for resources to be updated when name from IONOS Cloud is nil and `spec.forProvider.name` is not empty
- check for `spec.forProvider.name` field on `NodePool` K8s Managed Resource - for reconciliation loops

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [x] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [x] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [x] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [x] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
