### PR TITLE
fix: make ci run weekly instead of daily

### DIFF
--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -1,10 +1,10 @@
-name: CI [Daily]
+name: CI [Weekly]
 
 on:
   schedule:
-    # The job will run at 7am UTC
-    # every week day
-    - cron: '0 7 * * 1-5'
+    # The job will run at 9am UTC
+    # every week
+    - cron: '0 09 * * WED'
   workflow_dispatch: { }
 
 env:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

Run ci weekly instead of daily.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
