### PR TITLE
fix: remove cpufamily validation from nodepools

### DIFF
--- a/apis/k8s/v1alpha1/nodepool_types.go
+++ b/apis/k8s/v1alpha1/nodepool_types.go
@@ -63,7 +63,6 @@ type NodePoolParameters struct {
 	//
 	// +immutable
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:Enum=AMD_OPTERON;INTEL_SKYLAKE;INTEL_XEON
 	CPUFamily string `json:"cpuFamily,omitempty"`
 	// The number of cores for the node.
 	//


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

Remove cpufamily validation from nodepools, so any type of CPU can be used.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
