### PR TITLE
feat: use make provider.addtype to add new types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,43 @@ dev-clean: $(KIND) $(KUBECTL)
 # ====================================================================================
 # Special Targets
 
+# Install gomplate
+GOMPLATE_VERSION := 3.10.0
+GOMPLATE := $(TOOLS_HOST_DIR)/gomplate-$(GOMPLATE_VERSION)
+
+$(GOMPLATE):
+	@$(INFO) installing gomplate $(SAFEHOSTPLATFORM)
+	@mkdir -p $(TOOLS_HOST_DIR)
+	@curl -fsSLo $(GOMPLATE) https://github.com/hairyhenderson/gomplate/releases/download/v$(GOMPLATE_VERSION)/gomplate_$(SAFEHOSTPLATFORM) || $(FAIL)
+	@chmod +x $(GOMPLATE)
+	@$(OK) installing gomplate $(SAFEHOSTPLATFORM)
+
+export GOMPLATE
+
+# This target prepares repo for your provider by replacing all "template"
+# occurrences with your provider name.
+# This target can only be run once, if you want to rerun for some reason,
+# consider stashing/resetting your git state.
+# Arguments:
+#   provider: Camel case name of your provider, e.g. GitHub, PlanetScale
+provider.prepare:
+	@[ "${provider}" ] || ( echo "argument \"provider\" is not set"; exit 1 )
+	@PROVIDER=$(provider) ./hack/helpers/prepare.sh
+
+# This target adds a new api type and its controller.
+# You would still need to register new api in "apis/<provider>.go" and
+# controller in "internal/controller/<provider>.go".
+# Arguments:
+#   provider: Camel case name of your provider, e.g. GitHub, PlanetScale
+#   group: API group for the type you want to add.
+#   kind: Kind of the type you want to add
+#	apiversion: API version of the type you want to add. Optional and defaults to "v1alpha1"
+provider.addtype: $(GOMPLATE)
+	@[ "${provider}" ] || ( echo "argument \"provider\" is not set"; exit 1 )
+	@[ "${group}" ] || ( echo "argument \"group\" is not set"; exit 1 )
+	@[ "${kind}" ] || ( echo "argument \"kind\" is not set"; exit 1 )
+	@PROVIDER=$(provider) GROUP=$(group) KIND=$(kind) APIVERSION=$(apiversion) PROJECT_REPO=$(PROJECT_REPO) ./hack/helpers/addtype.sh
+
 define CROSSPLANE_MAKE_HELP
 Crossplane Targets:
     submodules            Update the submodules, such as the common build scripts.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,8 +5,10 @@
 - Add `DataplatformCluster` crd to support CRUD of Dataplatform clusters
 - Add `DataplatformNodepool` crd to support CRUD of Dataplatform clusters
 - Add `PICSlot` status field to `volume` and `nic` crds
+- Use `make provider.addtype` to add new types to the provider
 
 - **Documentation**:
+- Add server composition and claim example
 - Add docs on how to set pinning for crossplane provider. See [here](docs/README.md#authentication-on-ionos-cloud)
 
 ## [1.0.8] (December 2023)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/zapr v1.2.4
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/ionos-cloud/sdk-go-dataplatform v1.0.2
 	github.com/ionos-cloud/sdk-go-dbaas-mongo v1.3.1
@@ -49,7 +50,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -75,7 +75,7 @@ require (
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.8.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
-	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/term v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.13.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/go-logr/zapr v1.2.4
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
-	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/ionos-cloud/sdk-go-dataplatform v1.0.2
 	github.com/ionos-cloud/sdk-go-dbaas-mongo v1.3.1
@@ -50,6 +49,7 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
-golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
+golang.org/x/term v0.14.0 h1:LGK9IlZ8T9jvdy6cTdfKUCltatMFOehAQo9SRC46UQ8=
+golang.org/x/term v0.14.0/go.mod h1:TySc+nGkYR6qt8km8wUhuFRTVSMIX3XPR58y2lC8vww=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/hack/helpers/addtype.sh
+++ b/hack/helpers/addtype.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Crossplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please set ProviderNameLower & ProviderNameUpper environment variables before running this script.
+# See: https://github.com/crossplane/terrajet/blob/main/docs/generating-a-provider.md
+set -euo pipefail
+
+APIVERSION="${APIVERSION:-v1alpha1}"
+echo "Adding type ${KIND} to group ${GROUP} with version ${APIVERSION}"
+
+export GROUP
+export KIND
+export APIVERSION
+export PROVIDER
+export PROJECT_REPO
+
+kind_lower=$(echo "${KIND}" | tr "[:upper:]" "[:lower:]")
+group_lower=$(echo "${GROUP}" | tr "[:upper:]" "[:lower:]")
+
+mkdir -p "apis/${group_lower}/${APIVERSION}"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/GROUP_LOWER.go.tmpl" > "apis/${group_lower}/${group_lower}.go"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl" > "apis/${group_lower}/${APIVERSION}/${kind_lower}_types.go"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/APIVERSION/doc.go.tmpl" > "apis/${group_lower}/${APIVERSION}/doc.go"
+${GOMPLATE} < "hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl" > "apis/${group_lower}/${APIVERSION}/groupversion_info.go"
+
+mkdir -p "internal/controller/${kind_lower}"
+${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}.go"
+${GOMPLATE} < "hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl" > "internal/controller/${kind_lower}/${kind_lower}_test.go"
+
+
+

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/KIND_LOWER_types.go.tmpl
@@ -1,0 +1,86 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.APIVERSION }}
+
+import (
+	"reflect"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+)
+
+// {{ .Env.KIND }}Parameters are the configurable fields of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Parameters struct {
+	ConfigurableField string `json:"configurableField"`
+}
+
+// {{ .Env.KIND }}Observation are the observable fields of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Observation struct {
+	ObservableField string `json:"observableField,omitempty"`
+}
+
+// A {{ .Env.KIND }}Spec defines the desired state of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Spec struct {
+	xpv1.ResourceSpec `json:",inline"`
+	ForProvider       {{ .Env.KIND }}Parameters `json:"forProvider"`
+}
+
+// A {{ .Env.KIND }}Status represents the observed state of a {{ .Env.KIND }}.
+type {{ .Env.KIND }}Status struct {
+	xpv1.ResourceStatus `json:",inline"`
+	AtProvider          {{ .Env.KIND }}Observation `json:"atProvider,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// A {{ .Env.KIND }} is an example API type.
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
+// +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,{{ .Env.PROVIDER | strings.ToLower }}}
+type {{ .Env.KIND }} struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   {{ .Env.KIND }}Spec   `json:"spec"`
+	Status {{ .Env.KIND }}Status `json:"status,omitempty"`
+}
+
+// +kubebuilder:object:root=true
+
+// {{ .Env.KIND }}List contains a list of {{ .Env.KIND }}
+type {{ .Env.KIND }}List struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []{{ .Env.KIND }} `json:"items"`
+}
+
+// {{ .Env.KIND }} type metadata.
+var (
+	{{ .Env.KIND }}Kind             = reflect.TypeOf({{ .Env.KIND }}{}).Name()
+	{{ .Env.KIND }}GroupKind        = schema.GroupKind{Group: Group, Kind: {{ .Env.KIND }}Kind}.String()
+	{{ .Env.KIND }}KindAPIVersion   = {{ .Env.KIND }}Kind + "." + SchemeGroupVersion.String()
+	{{ .Env.KIND }}GroupVersionKind = SchemeGroupVersion.WithKind({{ .Env.KIND }}Kind)
+)
+
+func init() {
+	SchemeBuilder.Register(&{{ .Env.KIND }}{}, &{{ .Env.KIND }}List{})
+}

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/doc.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/doc.go.tmpl
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.APIVERSION | strings.ToLower }}

--- a/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/APIVERSION/groupversion_info.go.tmpl
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package v1alpha1 contains the v1alpha1 group Sample resources of the {{ .Env.PROVIDER }} provider.
+// +kubebuilder:object:generate=true
+// +groupName={{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io
+// +versionName={{ .Env.APIVERSION | strings.ToLower }}
+package {{ .Env.APIVERSION | strings.ToLower }}
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+// Package type metadata.
+const (
+	Group   = "{{ .Env.GROUP | strings.ToLower }}.{{ .Env.PROVIDER | strings.ToLower }}.crossplane.io"
+	Version = "{{ .Env.APIVERSION | strings.ToLower }}"
+)
+
+var (
+	// SchemeGroupVersion is group version used to register these objects
+	SchemeGroupVersion = schema.GroupVersion{Group: Group, Version: Version}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+)

--- a/hack/helpers/apis/GROUP_LOWER/GROUP_LOWER.go.tmpl
+++ b/hack/helpers/apis/GROUP_LOWER/GROUP_LOWER.go.tmpl
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package {{ .Env.GROUP | strings.ToLower }} contains group {{ .Env.GROUP }} API versions
+package {{ .Env.GROUP | strings.ToLower }}

--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
@@ -1,0 +1,199 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.KIND | strings.ToLower }}
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/connection"
+	"github.com/crossplane/crossplane-runtime/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	"{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/{{ .Env.GROUP | strings.ToLower }}/{{ .Env.APIVERSION | strings.ToLower }}"
+	apisv1alpha1 "{{ .Env.PROJECT_REPO | strings.ToLower }}/apis/v1alpha1"
+	"{{ .Env.PROJECT_REPO | strings.ToLower }}/internal/features"
+)
+
+const (
+	errNot{{ .Env.KIND }}    = "managed resource is not a {{ .Env.KIND }} custom resource"
+	errTrackPCUsage = "cannot track ProviderConfig usage"
+	errGetPC        = "cannot get ProviderConfig"
+	errGetCreds     = "cannot get credentials"
+
+	errNewClient = "cannot create new Service"
+)
+
+// A NoOpService does nothing.
+type NoOpService struct{}
+
+var (
+	newNoOpService = func(_ []byte) (interface{}, error) { return &NoOpService{}, nil }
+)
+
+// Setup adds a controller that reconciles {{ .Env.KIND }} managed resources.
+func Setup(mgr ctrl.Manager, o controller.Options) error {
+	name := managed.ControllerName(v1alpha1.{{ .Env.KIND }}GroupKind)
+
+	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
+	if o.Features.Enabled(features.EnableAlphaExternalSecretStores) {
+		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), apisv1alpha1.StoreConfigGroupVersionKind))
+	}
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(v1alpha1.{{ .Env.KIND }}GroupVersionKind),
+		managed.WithExternalConnecter(&connector{
+			kube:         mgr.GetClient(),
+			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
+			newServiceFn: newNoOpService}),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithPollInterval(o.PollInterval),
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+		managed.WithConnectionPublishers(cps...))
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named(name).
+		WithOptions(o.ForControllerRuntime()).
+		WithEventFilter(resource.DesiredStateChanged()).
+		For(&v1alpha1.{{ .Env.KIND }}{}).
+		Complete(ratelimiter.NewReconciler(name, r, o.GlobalRateLimiter))
+}
+
+// A connector is expected to produce an ExternalClient when its Connect method
+// is called.
+type connector struct {
+	kube         client.Client
+	usage        resource.Tracker
+	newServiceFn func(creds []byte) (interface{}, error)
+}
+
+// Connect typically produces an ExternalClient by:
+// 1. Tracking that the managed resource is using a ProviderConfig.
+// 2. Getting the managed resource's ProviderConfig.
+// 3. Getting the credentials specified by the ProviderConfig.
+// 4. Using the credentials to form a client.
+func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return nil, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	if err := c.usage.Track(ctx, mg); err != nil {
+		return nil, errors.Wrap(err, errTrackPCUsage)
+	}
+
+	pc := &apisv1alpha1.ProviderConfig{}
+	if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.GetProviderConfigReference().Name}, pc); err != nil {
+		return nil, errors.Wrap(err, errGetPC)
+	}
+
+	cd := pc.Spec.Credentials
+	data, err := resource.CommonCredentialExtractor(ctx, cd.Source, c.kube, cd.CommonCredentialSelectors)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetCreds)
+	}
+
+	svc, err := c.newServiceFn(data)
+	if err != nil {
+		return nil, errors.Wrap(err, errNewClient)
+	}
+
+	return &external{service: svc}, nil
+}
+
+// An ExternalClient observes, then either creates, updates, or deletes an
+// external resource to ensure it reflects the managed resource's desired state.
+type external struct {
+	// A 'client' used to connect to the external resource API. In practice this
+	// would be something like an AWS SDK client.
+	service interface{}
+}
+
+func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return managed.ExternalObservation{}, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	// These fmt statements should be removed in the real implementation.
+	fmt.Printf("Observing: %+v", cr)
+
+	return managed.ExternalObservation{
+		// Return false when the external resource does not exist. This lets
+		// the managed resource reconciler know that it needs to call Create to
+		// (re)create the resource, or that it has successfully been deleted.
+		ResourceExists: true,
+
+		// Return false when the external resource exists, but it not up to date
+		// with the desired managed resource state. This lets the managed
+		// resource reconciler know that it needs to call Update.
+		ResourceUpToDate: true,
+
+		// Return any details that may be required to connect to the external
+		// resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.ExternalCreation, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return managed.ExternalCreation{}, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	fmt.Printf("Creating: %+v", cr)
+
+	return managed.ExternalCreation{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return managed.ExternalUpdate{}, errors.New(errNot{{ .Env.KIND }})
+	}
+
+	fmt.Printf("Updating: %+v", cr)
+
+	return managed.ExternalUpdate{
+		// Optionally return any details that may be required to connect to the
+		// external resource. These will be stored as the connection secret.
+		ConnectionDetails: managed.ConnectionDetails{},
+	}, nil
+}
+
+func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
+	cr, ok := mg.(*v1alpha1.{{ .Env.KIND }})
+	if !ok {
+		return errors.New(errNot{{ .Env.KIND }})
+	}
+
+	fmt.Printf("Deleting: %+v", cr)
+
+	return nil
+}

--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER_test.go.tmpl
@@ -1,0 +1,74 @@
+/*
+Copyright 2022 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package {{ .Env.KIND | strings.ToLower }}
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+// Unlike many Kubernetes projects Crossplane does not use third party testing
+// libraries, per the common Go test review comments. Crossplane encourages the
+// use of table driven unit tests. The tests of the crossplane-runtime project
+// are representative of the testing style Crossplane encourages.
+//
+// https://github.com/golang/go/wiki/TestComments
+// https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md#contributing-code
+
+func TestObserve(t *testing.T) {
+	type fields struct {
+		service interface{}
+	}
+
+	type args struct {
+		ctx context.Context
+		mg  resource.Managed
+	}
+
+	type want struct {
+		o   managed.ExternalObservation
+		err error
+	}
+
+	cases := map[string]struct {
+		reason string
+		fields fields
+		args   args
+		want   want
+	}{
+		// TODO: Add test cases.
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			e := external{service: tc.fields.service}
+			got, err := e.Observe(tc.args.ctx, tc.args.mg)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want error, +got error:\n%s\n", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.o, got); diff != "" {
+				t.Errorf("\n%s\ne.Observe(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/hack/helpers/prepare.sh
+++ b/hack/helpers/prepare.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Crossplane Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please set ProviderNameLower & ProviderNameUpper environment variables before running this script.
+# See: https://github.com/crossplane/terrajet/blob/main/docs/generating-a-provider.md
+set -euo pipefail
+
+ProviderNameUpper=${PROVIDER}
+ProviderNameLower=$(echo "${PROVIDER}" | tr "[:upper:]" "[:lower:]")
+
+git rm -r apis/sample
+git rm -r internal/controller/mytype
+
+REPLACE_FILES='./* ./.github :!build/** :!go.* :!hack/**'
+# shellcheck disable=SC2086
+git grep -l 'template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/template/${ProviderNameLower}/g"
+# shellcheck disable=SC2086
+git grep -l 'Template' -- ${REPLACE_FILES} | xargs sed -i.bak "s/Template/${ProviderNameUpper}/g"
+# We need to be careful while replacing "template" keyword in go.mod as it could tamper
+# some imported packages under require section.
+sed -i.bak "s/provider-template/provider-${ProviderNameLower}/g" go.mod
+
+# Clean up the .bak files created by sed
+git clean -fd
+
+git mv "apis/template.go" "apis/${ProviderNameLower}.go"
+git mv "internal/controller/template.go" "internal/controller/${ProviderNameLower}.go"
+git mv "cluster/images/provider-template" "cluster/images/provider-${ProviderNameLower}"

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,32 @@
+/*
+ Copyright 2022 The Crossplane Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package features
+
+import "github.com/crossplane/crossplane-runtime/pkg/feature"
+
+// Feature flags.
+const (
+	// EnableAlphaExternalSecretStores enables alpha support for
+	// External Secret Stores. See the below design for more details.
+	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
+	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
+
+	// EnableAlphaManagementPolicies enables alpha support for
+	// Management Policies. See the below design for more details.
+	// https://github.com/crossplane/crossplane/blob/master/design/design-doc-observe-only-resources.md
+	EnableAlphaManagementPolicies feature.Flag = "EnableAlphaManagementPolicies"
+)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

Import from crossplane template to allow adding new types using make provider.addtype.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
