### PR TITLE
refactor: populate conversions, move functions using kube to own file

### DIFF
--- a/internal/controller/kube/kube.go
+++ b/internal/controller/kube/kube.go
@@ -1,0 +1,79 @@
+package kube
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
+)
+
+// Implements lower level functions to interact with kubernetes
+
+// GetVolume - returns a volume object from kubernetes
+func GetVolume(ctx context.Context, kube client.Client, volumeName, ns string) (*v1alpha1.Volume, error) {
+	obj := &v1alpha1.Volume{}
+	err := kube.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      volumeName,
+	}, obj)
+	return obj, err
+}
+
+// IsVolumeDeleted - checks if a volume is ready
+func IsVolumeDeleted(ctx context.Context, c client.Client, name, namespace string) (bool, error) {
+	_, err := GetVolume(ctx, c, name, namespace)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	}
+	return false, nil
+}
+
+// IsVolumeAvailable - checks if a volume is available
+func IsVolumeAvailable(ctx context.Context, c client.Client, name, namespace string) (bool, error) {
+	obj, err := GetVolume(ctx, c, name, namespace)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	if obj != nil && obj.Status.AtProvider.VolumeID != "" && strings.EqualFold(obj.Status.AtProvider.State, ionoscloud.Available) {
+		return true, nil
+	}
+	return false, err
+}
+
+// WaitForKubeResource - keeps retrying until resource meets condition, or until ctx is cancelled
+func WaitForKubeResource(ctx context.Context, timeoutInMinutes time.Duration, fn IsResourceReady, kube client.Client, name, namespace string) error {
+	if kube == nil {
+		return fmt.Errorf("kube client is nil")
+	}
+	if name == "" {
+		return fmt.Errorf("name is empty")
+	}
+	err := retry.RetryContext(ctx, timeoutInMinutes, func() *retry.RetryError {
+		isReady, err := fn(ctx, kube, name, namespace)
+		if isReady {
+			return nil
+		}
+		if err != nil {
+			retry.NonRetryableError(err)
+		}
+		return retry.RetryableError(fmt.Errorf("resource with name %v found, still trying ", name))
+	})
+	return err
+}
+
+// IsResourceReady polls kube api to see if resource is available and observed(status populated)
+type IsResourceReady func(ctx context.Context, kube client.Client, name, namespace string) (bool, error)

--- a/internal/controller/serverset/conversions.go
+++ b/internal/controller/serverset/conversions.go
@@ -1,0 +1,89 @@
+package serverset
+
+import (
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
+)
+
+// Conversions from serverset template to server, volume, nic objects
+
+// fromServerSetToServer is a conversion function that converts a ServerSet resource to a Server resource
+// attaches a bootvolume to the server based on replicaIndex
+func fromServerSetToServer(cr *v1alpha1.ServerSet, replicaIndex int) v1alpha1.Server {
+	serverType := "server"
+	return v1alpha1.Server{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      getNameFromIndex(cr.Name, serverType, replicaIndex),
+			Namespace: cr.Namespace,
+			Labels: map[string]string{
+				serverSetLabel: cr.Name,
+			},
+		},
+		ManagementPolicies: xpv1.ManagementPolicies{"*"},
+		Spec: v1alpha1.ServerSpec{
+			ForProvider: v1alpha1.ServerParameters{
+				DatacenterCfg:    cr.Spec.ForProvider.DatacenterCfg,
+				Name:             getNameFromIndex(cr.Name, serverType, replicaIndex),
+				Cores:            cr.Spec.ForProvider.Template.Spec.Cores,
+				RAM:              cr.Spec.ForProvider.Template.Spec.RAM,
+				AvailabilityZone: "AUTO",
+				CPUFamily:        cr.Spec.ForProvider.Template.Spec.CPUFamily,
+				VolumeCfg: v1alpha1.VolumeConfig{
+					VolumeIDRef: &xpv1.Reference{
+						Name: getNameFromIndex(cr.Name, "bootvolume", replicaIndex),
+					},
+				},
+			},
+		}}
+}
+
+func fromServerSetToVolume(cr *v1alpha1.ServerSet, name string) v1alpha1.Volume {
+	return v1alpha1.Volume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cr.Namespace,
+			Labels: map[string]string{
+				serverSetLabel: cr.Name,
+			},
+		},
+		ManagementPolicies: xpv1.ManagementPolicies{"*"},
+		Spec: v1alpha1.VolumeSpec{
+			ForProvider: v1alpha1.VolumeParameters{
+				DatacenterCfg:    cr.Spec.ForProvider.DatacenterCfg,
+				Name:             name,
+				AvailabilityZone: "AUTO",
+				Size:             cr.Spec.ForProvider.BootVolumeTemplate.Spec.Size,
+				Type:             cr.Spec.ForProvider.BootVolumeTemplate.Spec.Type,
+				Image:            cr.Spec.ForProvider.BootVolumeTemplate.Spec.Image,
+				// todo add to template(?)
+				ImagePassword: "imagePassword776",
+			},
+		}}
+}
+
+func fromServerSetToNic(cr *v1alpha1.ServerSet, name, serverID, lanID string) v1alpha1.Nic {
+	return v1alpha1.Nic{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: cr.GetNamespace(),
+			Labels: map[string]string{
+				serverSetLabel: cr.Name,
+			},
+		},
+		ManagementPolicies: xpv1.ManagementPolicies{"*"},
+		Spec: v1alpha1.NicSpec{
+			ForProvider: v1alpha1.NicParameters{
+				Name:          name,
+				DatacenterCfg: cr.Spec.ForProvider.DatacenterCfg,
+				ServerCfg: v1alpha1.ServerConfig{
+					ServerID: serverID,
+				},
+				LanCfg: v1alpha1.LanConfig{
+					LanID: lanID,
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/serverset/zz_conversions.go
+++ b/internal/controller/serverset/zz_conversions.go
@@ -1,1 +1,0 @@
-package serverset


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

Move functions that use kube Client to their own file
Convert from serverset template to server, nic, volume objects to own file.

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
