### PR TITLE
refactor: add delete to controllers, remove kubewrapper

### DIFF
--- a/internal/controller/serverset/kube.go
+++ b/internal/controller/serverset/kube.go
@@ -3,61 +3,14 @@ package serverset
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
 )
 
 const resourceReadyTimeout = 5 * time.Minute
 
 // Implements lower level functions to interact with kubernetes
-
-// wrapper - kubernetes client wrapper
-type wrapper struct {
-	kube client.Client
-	log  logging.Logger
-}
-
-// getObjectTypeFromName - returns a kubernetes object type based on name. Naming convention must be <serverset-name>-<object-type>-<index>-<version>
-func getObjectTypeFromName(name string) client.Object {
-	s := strings.Split(name, "-")[1]
-	switch s {
-	case resourceServer:
-		return &v1alpha1.Server{}
-	case resourceVolume, resourceBootVolume:
-		return &v1alpha1.Volume{}
-	case resourceNIC:
-		return &v1alpha1.Nic{}
-	default:
-		return nil
-	}
-}
-
-// isResourceDeleted - checks if a kube object is deleted. Extracts resource type from name,
-// support for server, bootvolume, volume, nic
-func (w *wrapper) isResourceDeleted(ctx context.Context, name, namespace string) (bool, error) {
-	w.log.Info("Checking if resource is deleted", "name", name, "namespace", namespace)
-	obj := getObjectTypeFromName(name)
-	err := w.kube.Get(ctx, types.NamespacedName{
-		Namespace: namespace,
-		Name:      name,
-	}, obj)
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			w.log.Info("Resource has been deleted", "name", name, "namespace", namespace)
-			return true, nil
-		}
-		return false, nil
-	}
-	return false, nil
-}
 
 // IsResourceReady polls kube api to see if resource is available and observed(status populated)
 type IsResourceReady func(ctx context.Context, name, namespace string) (bool, error)

--- a/internal/controller/serverset/setup.go
+++ b/internal/controller/serverset/setup.go
@@ -28,10 +28,7 @@ func SetupServerSet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.ServerSetGroupVersionKind),
 			managed.WithExternalConnecter(&connector{
-				kubeWrapper: wrapper{
-					kube: mgr.GetClient(),
-					log:  l,
-				},
+				kube: mgr.GetClient(),
 				bootVolumeController: &kubeBootVolumeController{
 					kube: mgr.GetClient(),
 					log:  l,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes
Remove kubewrapper.
Add Delete and IsResourceDeleted functions to controllers.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
