### PR TITLE
feat: add userdata, inject hostname to bootvolume

### DIFF
--- a/internal/controller/serverset/server_controller.go
+++ b/internal/controller/serverset/server_controller.go
@@ -144,9 +144,9 @@ func fromServerSetToServer(cr *v1alpha1.ServerSet, replicaIndex, version, volume
 		}}
 }
 
-// GetZoneFromIndex returns ZONE_1 for odd and ZONE_2 for even index
+// GetZoneFromIndex returns ZONE_2 for odd and ZONE_1 for even index
 func GetZoneFromIndex(index int) string {
-	return fmt.Sprintf("ZONE_%d", (index+1)%2+1)
+	return fmt.Sprintf("ZONE_%d", index%2+1)
 }
 
 func (k *kubeServerController) Ensure(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version, volumeVersion int) error {

--- a/internal/controller/serverset/server_controller.go
+++ b/internal/controller/serverset/server_controller.go
@@ -35,7 +35,6 @@ func (k *kubeServerController) Create(ctx context.Context, cr *v1alpha1.ServerSe
 	createServer := fromServerSetToServer(cr, replicaIndex, version, volumeVersion)
 	k.log.Info("Creating Server", "name", createServer.Name)
 
-	createServer.SetProviderConfigReference(cr.Spec.ProviderConfigReference)
 	if err := k.kube.Create(ctx, &createServer); err != nil {
 		return v1alpha1.Server{}, fmt.Errorf("while creating createServer %w ", err)
 	}
@@ -113,28 +112,32 @@ func (k *kubeServerController) isServerDeleted(ctx context.Context, name, namesp
 // fromServerSetToServer is a conversion function that converts a ServerSet resource to a Server resource
 // attaches a bootvolume to the server based on replicaIndex
 func fromServerSetToServer(cr *v1alpha1.ServerSet, replicaIndex, version, volumeVersion int) v1alpha1.Server {
-	serverType := "server"
 	return v1alpha1.Server{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getNameFromIndex(cr.Name, serverType, replicaIndex, version),
+			Name:      getNameFromIndex(cr.Name, resourceServer, replicaIndex, version),
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				serverSetLabel:                        cr.Name,
-				fmt.Sprintf(indexLabel, serverType):   fmt.Sprintf("%d", replicaIndex),
-				fmt.Sprintf(versionLabel, serverType): fmt.Sprintf("%d", version),
+				serverSetLabel:                            cr.Name,
+				fmt.Sprintf(indexLabel, resourceServer):   fmt.Sprintf("%d", replicaIndex),
+				fmt.Sprintf(versionLabel, resourceServer): fmt.Sprintf("%d", version),
 			},
 		},
 		Spec: v1alpha1.ServerSpec{
+			ResourceSpec: xpv1.ResourceSpec{
+				ProviderConfigReference: cr.GetProviderConfigReference(),
+				ManagementPolicies:      cr.GetManagementPolicies(),
+				DeletionPolicy:          cr.GetDeletionPolicy(),
+			},
 			ForProvider: v1alpha1.ServerParameters{
 				DatacenterCfg:    cr.Spec.ForProvider.DatacenterCfg,
-				Name:             getNameFromIndex(cr.Name, serverType, replicaIndex, version),
+				Name:             getNameFromIndex(cr.Name, resourceServer, replicaIndex, version),
 				Cores:            cr.Spec.ForProvider.Template.Spec.Cores,
 				RAM:              cr.Spec.ForProvider.Template.Spec.RAM,
 				AvailabilityZone: GetZoneFromIndex(replicaIndex),
 				CPUFamily:        cr.Spec.ForProvider.Template.Spec.CPUFamily,
 				VolumeCfg: v1alpha1.VolumeConfig{
 					VolumeIDRef: &xpv1.Reference{
-						Name: getNameFromIndex(cr.Name, "bootvolume", replicaIndex, volumeVersion),
+						Name: getNameFromIndex(cr.Name, resourceBootVolume, replicaIndex, volumeVersion),
 					},
 				},
 			},

--- a/internal/controller/serverset/server_controller_test.go
+++ b/internal/controller/serverset/server_controller_test.go
@@ -1,0 +1,57 @@
+package serverset
+
+import "testing"
+
+func TestGetZoneFromIndex(t *testing.T) {
+	type args struct {
+		index int
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "index1ExpectedZone_1",
+			args: args{
+				index: 0,
+			},
+			want: "ZONE_1",
+		},
+		{
+			name: "index1ExpectedZone_2",
+			args: args{
+				index: 1,
+			},
+			want: "ZONE_2",
+		},
+		{
+			name: "index2ExpectedZone_1",
+			args: args{
+				index: 2,
+			},
+			want: "ZONE_1",
+		},
+		{
+			name: "index10ExpectedZone_1",
+			args: args{
+				index: 10,
+			},
+			want: "ZONE_1",
+		},
+		{
+			name: "index111ExpectedZone_2",
+			args: args{
+				index: 111,
+			},
+			want: "ZONE_2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetZoneFromIndex(tt.args.index); got != tt.want {
+				t.Errorf("GetZoneFromIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ccpatch/patch_userdata.go
+++ b/pkg/ccpatch/patch_userdata.go
@@ -19,6 +19,8 @@ var (
 	ErrMalformedData = errors.New("malformed cloud-init data")
 )
 
+const cloudConfigHeader = "#cloud-config"
+
 // CloudInitPatcher is a helper to patch cloud-init userdata
 type CloudInitPatcher struct {
 	raw     string
@@ -31,7 +33,7 @@ type CloudInitPatcher struct {
 func NewCloudInitPatcher(raw string) (*CloudInitPatcher, error) {
 	byt, err := base64.StdEncoding.DecodeString(raw)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding base64: %w (%w)", ErrDecodeFailed, err)
+		return nil, fmt.Errorf("%w (%w)", ErrDecodeFailed, err)
 	}
 
 	if len(byt) == 0 {
@@ -44,7 +46,7 @@ func NewCloudInitPatcher(raw string) (*CloudInitPatcher, error) {
 
 	data := make(map[string]interface{})
 	if err := yaml.Unmarshal(byt, &data); err != nil {
-		return nil, fmt.Errorf("error unmarshalling yaml: %w (%w)", ErrMalformedData, err)
+		return nil, fmt.Errorf("%w (%w)", ErrMalformedData, err)
 	}
 
 	return &CloudInitPatcher{raw: raw, decoded: string(byt), data: data}, nil
@@ -69,7 +71,7 @@ func (c *CloudInitPatcher) String() string {
 	}
 
 	// add #cloud-config header
-	byt = append([]byte("#cloud-config\n"), byt...)
+	byt = append([]byte(cloudConfigHeader+"\n"), byt...)
 
 	return string(byt)
 }
@@ -88,5 +90,5 @@ func IsCloudConfig(userdata string) bool {
 	// Trim trailing whitespaces
 	header = strings.TrimRightFunc(header, unicode.IsSpace)
 
-	return header == "#cloud-config"
+	return header == cloudConfigHeader
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

Add userdata tp bootvolume
Inject hostname to bootvolume
Minor fixes, use const everywhere
getZoneFromIndex - should return ZONE_1 for even, ZONE_2 for odd

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
