### PR TITLE
fix: set lan name from metadata name of template

### DIFF
--- a/examples/ionoscloud/compute/statefulserverset.yaml
+++ b/examples/ionoscloud/compute/statefulserverset.yaml
@@ -35,7 +35,8 @@ spec:
         nics:
           - name: nic-sample
             ipv4: "10.0.0.1/24"
-            reference: examplelan
+#           should reference lan metadata name
+            reference: data
         volumeMounts:
           - reference: "volume-mount-id"
         bootStorageVolumeRef: "volume-id"

--- a/internal/controller/compute/statefulserverset/lan_controller.go
+++ b/internal/controller/compute/statefulserverset/lan_controller.go
@@ -38,7 +38,7 @@ type kubeLANController struct {
 
 // Create creates a lan CR and waits until in reaches AVAILABLE state
 func (k *kubeLANController) Create(ctx context.Context, cr *v1alpha1.StatefulServerSet, lanIndex int) (v1alpha1.Lan, error) {
-	name := fmt.Sprintf("%s-%s-%d", cr.GetName(), resourceLAN, lanIndex)
+	name := cr.Spec.ForProvider.Lans[lanIndex].Metadata.Name
 	k.log.Info("Creating LAN", "name", name)
 
 	createLAN := fromStatefulServerSetToLAN(cr, name, lanIndex)


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
