### PR TITLE
Fix/allow multiple serversets

### DIFF
--- a/examples/ionoscloud/compute/statefulserverset.yaml
+++ b/examples/ionoscloud/compute/statefulserverset.yaml
@@ -35,7 +35,8 @@ spec:
         nics:
           - name: nic-sample
             ipv4: "10.0.0.1/24"
-            reference: examplelan
+#           should reference lan metadata name
+            reference: data
         volumeMounts:
           - reference: "volume-mount-id"
         bootStorageVolumeRef: "volume-id"

--- a/internal/controller/compute/statefulserverset/lan_controller.go
+++ b/internal/controller/compute/statefulserverset/lan_controller.go
@@ -38,7 +38,7 @@ type kubeLANController struct {
 
 // Create creates a lan CR and waits until in reaches AVAILABLE state
 func (k *kubeLANController) Create(ctx context.Context, cr *v1alpha1.StatefulServerSet, lanIndex int) (v1alpha1.Lan, error) {
-	name := fmt.Sprintf("%s-%s-%d", cr.GetName(), resourceLAN, lanIndex)
+	name := cr.Spec.ForProvider.Lans[lanIndex].Metadata.Name
 	k.log.Info("Creating LAN", "name", name)
 
 	createLAN := fromStatefulServerSetToLAN(cr, name, lanIndex)

--- a/internal/controller/serverset/bootvolume_controller.go
+++ b/internal/controller/serverset/bootvolume_controller.go
@@ -118,8 +118,8 @@ func fromServerSetToVolume(cr *v1alpha1.ServerSet, name string, replicaIndex, ve
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
 				serverSetLabel: cr.Name,
-				fmt.Sprintf(indexLabel, resourceBootVolume):   fmt.Sprintf("%d", replicaIndex),
-				fmt.Sprintf(versionLabel, resourceBootVolume): fmt.Sprintf("%d", version),
+				fmt.Sprintf(indexLabel, cr.GetName(), resourceBootVolume):   fmt.Sprintf("%d", replicaIndex),
+				fmt.Sprintf(versionLabel, cr.GetName(), resourceBootVolume): fmt.Sprintf("%d", version),
 			},
 		},
 		Spec: v1alpha1.VolumeSpec{
@@ -146,7 +146,7 @@ func fromServerSetToVolume(cr *v1alpha1.ServerSet, name string, replicaIndex, ve
 func (k *kubeBootVolumeController) Ensure(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int) error {
 	k.log.Info("Ensuring BootVolume", "replicaIndex", replicaIndex, "version", version)
 	res := &v1alpha1.VolumeList{}
-	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, resourceBootVolume, replicaIndex, version, res); err != nil {
+	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, cr.GetName(), resourceBootVolume, replicaIndex, version, res); err != nil {
 		return err
 	}
 	volumes := res.Items

--- a/internal/controller/serverset/nic_controller.go
+++ b/internal/controller/serverset/nic_controller.go
@@ -123,9 +123,9 @@ func fromServerSetToNic(cr *v1alpha1.ServerSet, name, serverID, lanID string, re
 			Name:      name,
 			Namespace: cr.GetNamespace(),
 			Labels: map[string]string{
-				serverSetLabel:                         cr.Name,
-				fmt.Sprintf(indexLabel, resourceNIC):   fmt.Sprintf("%d", replicaIndex),
-				fmt.Sprintf(versionLabel, resourceNIC): fmt.Sprintf("%d", version),
+				serverSetLabel: cr.Name,
+				fmt.Sprintf(indexLabel, cr.GetName(), resourceNIC):   fmt.Sprintf("%d", replicaIndex),
+				fmt.Sprintf(versionLabel, cr.GetName(), resourceNIC): fmt.Sprintf("%d", version),
 			},
 		},
 		Spec: v1alpha1.NicSpec{
@@ -152,7 +152,7 @@ func fromServerSetToNic(cr *v1alpha1.ServerSet, name, serverID, lanID string, re
 func (k *kubeNicController) EnsureNICs(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int) error {
 	k.log.Info("Ensuring NICs", "index", replicaIndex, "version", version)
 	res := &v1alpha1.ServerList{}
-	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, ResourceServer, replicaIndex, version, res); err != nil {
+	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, cr.GetName(), ResourceServer, replicaIndex, version, res); err != nil {
 		return err
 	}
 	servers := res.Items
@@ -172,7 +172,7 @@ func (k *kubeNicController) EnsureNICs(ctx context.Context, cr *v1alpha1.ServerS
 // EnsureNIC - creates a NIC if it does not exist
 func (k *kubeNicController) ensure(ctx context.Context, cr *v1alpha1.ServerSet, serverID, lanName string, replicaIndex, version int) error {
 	res := &v1alpha1.NicList{}
-	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, resourceNIC, replicaIndex, version, res); err != nil {
+	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, cr.GetName(), resourceNIC, replicaIndex, version, res); err != nil {
 		return err
 	}
 	nic := v1alpha1.Nic{}

--- a/internal/controller/serverset/server_controller.go
+++ b/internal/controller/serverset/server_controller.go
@@ -118,9 +118,9 @@ func fromServerSetToServer(cr *v1alpha1.ServerSet, replicaIndex, version, volume
 			Name:      getNameFromIndex(cr.Name, ResourceServer, replicaIndex, version),
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				serverSetLabel:                            cr.Name,
-				fmt.Sprintf(indexLabel, ResourceServer):   fmt.Sprintf("%d", replicaIndex),
-				fmt.Sprintf(versionLabel, ResourceServer): fmt.Sprintf("%d", version),
+				serverSetLabel: cr.Name,
+				fmt.Sprintf(indexLabel, cr.GetName(), ResourceServer):   fmt.Sprintf("%d", replicaIndex),
+				fmt.Sprintf(versionLabel, cr.GetName(), ResourceServer): fmt.Sprintf("%d", version),
 			},
 		},
 		Spec: v1alpha1.ServerSpec{
@@ -153,7 +153,7 @@ func GetZoneFromIndex(index int) string {
 func (k *kubeServerController) Ensure(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version, volumeVersion int) error {
 	k.log.Info("Ensuring Server", "index", replicaIndex, "version", version)
 	res := &v1alpha1.ServerList{}
-	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, ResourceServer, replicaIndex, version, res); err != nil {
+	if err := listResFromSSetWithIndexAndVersion(ctx, k.kube, cr.GetName(), ResourceServer, replicaIndex, version, res); err != nil {
 		return err
 	}
 	servers := res.Items

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -46,9 +46,9 @@ const (
 
 const (
 	// indexLabel is the label used to identify the server set by index
-	indexLabel = "ionoscloud.com/serverset-%s-index"
+	indexLabel = "ionoscloud.com/%s-%s-index"
 	// versionLabel is the label used to identify the server set by version
-	versionLabel = "ionoscloud.com/serverset-%s-version"
+	versionLabel = "ionoscloud.com/%s-%s-version"
 	// serverSetLabel is the label used to identify the server set resources. All resources created by a server set will have this label
 	serverSetLabel = "ionoscloud.com/serverset"
 )
@@ -355,7 +355,7 @@ func (e *external) updateOrRecreateVolumes(ctx context.Context, cr *v1alpha1.Ser
 }
 
 func (e *external) updateByIndex(ctx context.Context, idx int, cr *v1alpha1.ServerSet) error {
-	volumeVersion, serverVersion, err := getVersionsFromVolumeAndServer(ctx, e.kube, idx)
+	volumeVersion, serverVersion, err := getVersionsFromVolumeAndServer(ctx, e.kube, cr.GetName(), idx)
 	if err != nil {
 		return err
 	}
@@ -533,24 +533,24 @@ func (e *external) getVolumesFromServerSet(ctx context.Context, name string) ([]
 }
 
 // ListResFromSSetWithIndex - lists resources from a server set with a specific index label
-func ListResFromSSetWithIndex(ctx context.Context, kube client.Client, resType string, index int, list client.ObjectList) error {
+func ListResFromSSetWithIndex(ctx context.Context, kube client.Client, serversetName, resType string, index int, list client.ObjectList) error {
 	return kube.List(ctx, list, client.MatchingLabels{
-		fmt.Sprintf(indexLabel, resType): strconv.Itoa(index),
+		fmt.Sprintf(indexLabel, serversetName, resType): strconv.Itoa(index),
 	})
 }
 
 // listResFromSSetWithIndexAndVersion - lists resources from a server set with a specific index and version label
-func listResFromSSetWithIndexAndVersion(ctx context.Context, kube client.Client, resType string, index, version int, list client.ObjectList) error {
+func listResFromSSetWithIndexAndVersion(ctx context.Context, kube client.Client, serversetName, resType string, index, version int, list client.ObjectList) error {
 	return kube.List(ctx, list, client.MatchingLabels{
-		fmt.Sprintf(versionLabel, resType): strconv.Itoa(version),
-		fmt.Sprintf(indexLabel, resType):   strconv.Itoa(index),
+		fmt.Sprintf(versionLabel, serversetName, resType): strconv.Itoa(version),
+		fmt.Sprintf(indexLabel, serversetName, resType):   strconv.Itoa(index),
 	})
 }
 
 // getVersionsFromVolumeAndServer checks that there is only one server and volume and returns their version
-func getVersionsFromVolumeAndServer(ctx context.Context, kube client.Client, replicaIndex int) (volumeVersion int, serverVersion int, err error) {
+func getVersionsFromVolumeAndServer(ctx context.Context, kube client.Client, serversetName string, replicaIndex int) (volumeVersion int, serverVersion int, err error) {
 	volumeResources := &v1alpha1.VolumeList{}
-	err = ListResFromSSetWithIndex(ctx, kube, resourceBootVolume, replicaIndex, volumeResources)
+	err = ListResFromSSetWithIndex(ctx, kube, serversetName, resourceBootVolume, replicaIndex, volumeResources)
 	if err != nil {
 		return volumeVersion, serverVersion, err
 	}
@@ -561,7 +561,7 @@ func getVersionsFromVolumeAndServer(ctx context.Context, kube client.Client, rep
 		return volumeVersion, serverVersion, fmt.Errorf("found no volumes for index %d ", replicaIndex)
 	}
 	serverResources := &v1alpha1.ServerList{}
-	err = ListResFromSSetWithIndex(ctx, kube, ResourceServer, replicaIndex, serverResources)
+	err = ListResFromSSetWithIndex(ctx, kube, serversetName, ResourceServer, replicaIndex, serverResources)
 	if err != nil {
 		return volumeVersion, serverVersion, err
 	}
@@ -573,13 +573,13 @@ func getVersionsFromVolumeAndServer(ctx context.Context, kube client.Client, rep
 	}
 
 	condemnedVolume := volumeResources.Items[0]
-	volumeVersion, err = strconv.Atoi(condemnedVolume.Labels[fmt.Sprintf(versionLabel, resourceBootVolume)])
+	volumeVersion, err = strconv.Atoi(condemnedVolume.Labels[fmt.Sprintf(versionLabel, serversetName, resourceBootVolume)])
 	if err != nil {
 		return volumeVersion, serverVersion, err
 	}
 
 	servers := serverResources.Items
-	serverVersion, err = strconv.Atoi(servers[0].Labels[fmt.Sprintf(versionLabel, ResourceServer)])
+	serverVersion, err = strconv.Atoi(servers[0].Labels[fmt.Sprintf(versionLabel, serversetName, ResourceServer)])
 	if err != nil {
 		return volumeVersion, serverVersion, err
 	}
@@ -588,7 +588,7 @@ func getVersionsFromVolumeAndServer(ctx context.Context, kube client.Client, rep
 
 func (e *external) ensureServerAndNicByIndex(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int) error {
 	resSrv := &v1alpha1.ServerList{}
-	if err := ListResFromSSetWithIndex(ctx, e.kube, ResourceServer, replicaIndex, resSrv); err != nil {
+	if err := ListResFromSSetWithIndex(ctx, e.kube, cr.GetName(), ResourceServer, replicaIndex, resSrv); err != nil {
 		return err
 	}
 	if len(resSrv.Items) > 1 {
@@ -597,12 +597,12 @@ func (e *external) ensureServerAndNicByIndex(ctx context.Context, cr *v1alpha1.S
 	if len(resSrv.Items) == 0 {
 		res := &v1alpha1.VolumeList{}
 		volumeVersion := version
-		if err := ListResFromSSetWithIndex(ctx, e.kube, resourceBootVolume, replicaIndex, res); err != nil {
+		if err := ListResFromSSetWithIndex(ctx, e.kube, cr.GetName(), resourceBootVolume, replicaIndex, res); err != nil {
 			return err
 		}
 		if len(res.Items) > 0 {
 			var err error
-			volumeVersion, err = strconv.Atoi(res.Items[0].Labels[fmt.Sprintf(versionLabel, resourceBootVolume)])
+			volumeVersion, err = strconv.Atoi(res.Items[0].Labels[fmt.Sprintf(versionLabel, cr.GetName(), resourceBootVolume)])
 			if err != nil {
 				return err
 			}
@@ -620,7 +620,7 @@ func (e *external) ensureServerAndNicByIndex(ctx context.Context, cr *v1alpha1.S
 // ensureBootVolumeByIndex - ensures boot volume created for a specific index. After checking for index, it checks for index and version
 func (e *external) ensureBootVolumeByIndex(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int) error {
 	res := &v1alpha1.VolumeList{}
-	if err := ListResFromSSetWithIndex(ctx, e.kube, resourceBootVolume, replicaIndex, res); err != nil {
+	if err := ListResFromSSetWithIndex(ctx, e.kube, cr.GetName(), resourceBootVolume, replicaIndex, res); err != nil {
 		return err
 	}
 	if len(res.Items) > 1 {

--- a/internal/controller/volumeselector/volumeselector.go
+++ b/internal/controller/volumeselector/volumeselector.go
@@ -260,7 +260,7 @@ func (c *externalVolumeselector) getVolumesAndServers(ctx context.Context, serve
 	}
 	// get server by index
 
-	err = serverset.ListResFromSSetWithIndex(ctx, c.kube, serverset.ResourceServer, replicaIndex, &serverList)
+	err = serverset.ListResFromSSetWithIndex(ctx, c.kube, serversetName, serverset.ResourceServer, replicaIndex, &serverList)
 	if err != nil {
 		return volumeList, serverList, err
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes
Add serverset kube name to sub-resource labels to make sure they are unique in case multiple serversets are created in the same namespace.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
