### PR TITLE
feat: move volumeselector to ssset

### DIFF
--- a/internal/controller/compute/statefulserverset/serverset_controller.go
+++ b/internal/controller/compute/statefulserverset/serverset_controller.go
@@ -3,7 +3,6 @@ package statefulserverset
 import (
 	"context"
 	"fmt"
-	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -18,11 +17,9 @@ import (
 
 type kubeSSetControlManager interface {
 	Create(ctx context.Context, cr *v1alpha1.StatefulServerSet) (*v1alpha1.ServerSet, error)
-	Ensure(ctx context.Context, cr *v1alpha1.StatefulServerSet, w waitUntilAvailable) error
+	Ensure(ctx context.Context, cr *v1alpha1.StatefulServerSet) error
 	Update(ctx context.Context, cr *v1alpha1.StatefulServerSet) (v1alpha1.ServerSet, error)
 }
-
-type waitUntilAvailable func(ctx context.Context, timeoutInMinutes time.Duration, fn kube.IsResourceReady, name, namespace string) error
 
 // kubeServerSetController - kubernetes client wrapper for server set resources
 type kubeServerSetController struct {
@@ -90,8 +87,8 @@ func (k *kubeServerSetController) isAvailable(ctx context.Context, name, namespa
 	return false, err
 }
 
-// Ensure - creates a server set if it does not exist
-func (k *kubeServerSetController) Ensure(ctx context.Context, cr *v1alpha1.StatefulServerSet, wait waitUntilAvailable) error {
+// Ensure - creates a server set if it does not exist and waits until it is ready
+func (k *kubeServerSetController) Ensure(ctx context.Context, cr *v1alpha1.StatefulServerSet) error {
 	SSetName := getSSetName(cr)
 	k.log.Info("Ensuring ServerSet CR", "name", SSetName)
 	kubeSSet := &v1alpha1.ServerSet{}
@@ -103,7 +100,7 @@ func (k *kubeServerSetController) Ensure(ctx context.Context, cr *v1alpha1.State
 		if err != nil {
 			return err
 		}
-		return wait(ctx, kube.ResourceReadyTimeout, k.isAvailable, SSetName, cr.Namespace)
+		return kube.WaitForResource(ctx, kube.ResourceReadyTimeout, k.isAvailable, SSetName, cr.Namespace)
 	case err != nil:
 		return err
 	default:

--- a/internal/controller/compute/statefulserverset/serverset_controller_test.go
+++ b/internal/controller/compute/statefulserverset/serverset_controller_test.go
@@ -3,6 +3,7 @@ package statefulserverset
 import (
 	"context"
 	"testing"
+	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -34,14 +35,16 @@ func getReturnsSSet(ctx context.Context, watch client.WithWatch, key client.Obje
 }
 
 func Test_kubeServerSetController_Ensure(t *testing.T) {
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	type fields struct {
-		kube client.Client
-		log  logging.Logger
+		kube           client.Client
+		log            logging.Logger
+		ssetController kubeSSetControlManager
 	}
 	type args struct {
 		ctx context.Context
 		cr  *v1alpha1.StatefulServerSet
-		w   waitUntilAvailable
 	}
 	tests := []struct {
 		name    string
@@ -56,11 +59,10 @@ func Test_kubeServerSetController_Ensure(t *testing.T) {
 				log:  logging.NewNopLogger(),
 			},
 			args: args{
-				ctx: context.Background(),
+				ctx: ctxWithTimeout,
 				cr:  &v1alpha1.StatefulServerSet{ObjectMeta: metav1.ObjectMeta{Name: statefulServerSetName}},
-				w:   fakeWaitUntilAvailable,
 			},
-			wantErr: nil,
+			wantErr: context.DeadlineExceeded,
 		},
 		{
 			name: "error received on server set creation, then return error",
@@ -71,7 +73,6 @@ func Test_kubeServerSetController_Ensure(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				cr:  &v1alpha1.StatefulServerSet{ObjectMeta: metav1.ObjectMeta{Name: statefulServerSetName}},
-				w:   fakeWaitUntilAvailable,
 			},
 			wantErr: ErrSomethingWentWrong,
 		},
@@ -84,7 +85,6 @@ func Test_kubeServerSetController_Ensure(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				cr:  &v1alpha1.StatefulServerSet{ObjectMeta: metav1.ObjectMeta{Name: statefulServerSetName}},
-				w:   fakeWaitUntilAvailable,
 			},
 			wantErr: ErrSomethingWentWrong,
 		},
@@ -97,7 +97,6 @@ func Test_kubeServerSetController_Ensure(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				cr:  &v1alpha1.StatefulServerSet{ObjectMeta: metav1.ObjectMeta{Name: statefulServerSetName}},
-				w:   fakeWaitUntilAvailable,
 			},
 			wantErr: nil,
 		},
@@ -108,7 +107,7 @@ func Test_kubeServerSetController_Ensure(t *testing.T) {
 				kube: tt.fields.kube,
 				log:  tt.fields.log,
 			}
-			err := k.Ensure(tt.args.ctx, tt.args.cr, tt.args.w)
+			err := k.Ensure(tt.args.ctx, tt.args.cr)
 			assert.Equal(t, tt.wantErr, err)
 		})
 	}

--- a/internal/controller/compute/statefulserverset/serverset_controller_test.go
+++ b/internal/controller/compute/statefulserverset/serverset_controller_test.go
@@ -38,9 +38,8 @@ func Test_kubeServerSetController_Ensure(t *testing.T) {
 	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	type fields struct {
-		kube           client.Client
-		log            logging.Logger
-		ssetController kubeSSetControlManager
+		kube client.Client
+		log  logging.Logger
 	}
 	type args struct {
 		ctx context.Context

--- a/internal/controller/compute/statefulserverset/setup.go
+++ b/internal/controller/compute/statefulserverset/setup.go
@@ -43,6 +43,10 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, opts *u
 					kube: mgr.GetClient(),
 					log:  l,
 				},
+				volumeSelectorController: &kubeVolumeSelectorController{
+					kube: mgr.GetClient(),
+					log:  l,
+				},
 			}),
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),

--- a/internal/controller/compute/statefulserverset/statefulserverset_test.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset_test.go
@@ -23,10 +23,15 @@ func Test_statefulServerSetController_Create(t *testing.T) {
 			ensure: 0,
 		},
 	}
+	volSetCtrl := &fakeKubeVolumeSelectorController{
+		Volume: v1alpha1.Volumeselector{},
+		Err:    nil,
+	}
 	type fields struct {
 		kube           client.Client
 		log            logging.Logger
 		SSetController kubeSSetControlManager
+		volSetCtrl     kubeVolumeSelectorManager
 	}
 	type args struct {
 		ctx context.Context
@@ -45,6 +50,7 @@ func Test_statefulServerSetController_Create(t *testing.T) {
 				kube:           fakeKubeClientWithObjs(),
 				log:            logging.NewNopLogger(),
 				SSetController: SSetCtrl,
+				volSetCtrl:     volSetCtrl,
 			},
 			args: args{
 				ctx: context.Background(),
@@ -57,9 +63,10 @@ func Test_statefulServerSetController_Create(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &external{
-				kube:           tt.fields.kube,
-				log:            tt.fields.log,
-				SSetController: tt.fields.SSetController,
+				kube:                     tt.fields.kube,
+				log:                      tt.fields.log,
+				SSetController:           tt.fields.SSetController,
+				volumeSelectorController: tt.fields.volSetCtrl,
 			}
 			got, err := c.Create(tt.args.ctx, tt.args.mg)
 			if (err != nil) != tt.wantErr {

--- a/internal/controller/serverset/const.go
+++ b/internal/controller/serverset/const.go
@@ -12,6 +12,3 @@ const (
 	statusUnknown = "UNKNOWN"
 	statusError   = "ERROR"
 )
-
-// <serverset_name>-volume-selector
-const volumeSelectorName = "%s-volume-selector"

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -34,9 +34,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
-
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
+
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
 )
 
 const (
@@ -56,13 +56,12 @@ const (
 // A connector is expected to produce an ExternalClient when its Connect method
 // is called.
 type connector struct {
-	kube                     client.Client
-	bootVolumeController     kubeBootVolumeControlManager
-	nicController            kubeNicControlManager
-	serverController         kubeServerControlManager
-	volumeSelectorController kubeVolumeSelectorManager
-	usage                    resource.Tracker
-	log                      logging.Logger
+	kube                 client.Client
+	bootVolumeController kubeBootVolumeControlManager
+	nicController        kubeNicControlManager
+	serverController     kubeServerControlManager
+	usage                resource.Tracker
+	log                  logging.Logger
 }
 
 // Connect typically produces an ExternalClient by:
@@ -81,12 +80,11 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	}
 
 	return &external{
-		kube:                     c.kube,
-		log:                      c.log,
-		bootVolumeController:     c.bootVolumeController,
-		nicController:            c.nicController,
-		serverController:         c.serverController,
-		volumeSelectorController: c.volumeSelectorController,
+		kube:                 c.kube,
+		log:                  c.log,
+		bootVolumeController: c.bootVolumeController,
+		nicController:        c.nicController,
+		serverController:     c.serverController,
 	}, err
 }
 
@@ -96,11 +94,10 @@ type external struct {
 	kube client.Client
 	// A 'client' used to connect to the externalServer resource API. In practice this
 	// would be something like an IONOS Cloud SDK client.
-	bootVolumeController     kubeBootVolumeControlManager
-	nicController            kubeNicControlManager
-	serverController         kubeServerControlManager
-	volumeSelectorController kubeVolumeSelectorManager
-	log                      logging.Logger
+	bootVolumeController kubeBootVolumeControlManager
+	nicController        kubeNicControlManager
+	serverController     kubeServerControlManager
+	log                  logging.Logger
 }
 
 func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -212,10 +209,6 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 			return managed.ExternalCreation{}, err
 		}
 
-	}
-	// volume selector attaches data volumes to the servers created in the serverset
-	if err := e.volumeSelectorController.CreateOrUpdate(ctx, cr); err != nil {
-		return managed.ExternalCreation{}, err
 	}
 
 	// When all conditions are met, the managed resource is considered available
@@ -433,13 +426,6 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 	}
 	e.log.Info("Boot Volumes successfully deleted")
 
-	e.log.Info("Deleting the Volume Selectors with label", "label", cr.Name)
-	if err := e.kube.DeleteAllOf(ctx, &v1alpha1.Volumeselector{}, client.InNamespace(cr.Namespace), client.MatchingLabels{
-		serverSetLabel: cr.Name,
-	}); err != nil {
-		return err
-	}
-	e.log.Info("Volume Selectors successfully deleted")
 	return nil
 }
 

--- a/internal/controller/serverset/setup.go
+++ b/internal/controller/serverset/setup.go
@@ -41,10 +41,6 @@ func SetupServerSet(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter
 					kube: mgr.GetClient(),
 					log:  l,
 				},
-				volumeSelectorController: &kubeVolumeSelectorController{
-					kube: mgr.GetClient(),
-					log:  l,
-				},
 				usage: resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 				log:   l,
 			}),


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes
Volumeselector needs to be created in the statefulserverset, no in serverset.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
