### PR TITLE
fix: allow pre-release crossplane versions

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -4,7 +4,7 @@ metadata:
   name: provider-ionoscloud
 spec:
   crossplane:
-    version: ">=v1.0.0"
+    version: ">=v1.0.0-0"
   controller:
     image: ghcr.io/ionos-cloud/crossplane-provider-ionoscloud-controller:VERSION
   annotations:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:
Allows the provide to be installed with pre-release crossplane versions, such as 1.16.0-rc.1
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
