### PR TITLE
Feat/ssset should get state updates from servers and volumes

### DIFF
--- a/internal/controller/compute/statefulserverset/objects_test.go
+++ b/internal/controller/compute/statefulserverset/objects_test.go
@@ -397,15 +397,12 @@ func createVolumeDefault() v1alpha1.Volume {
 	return volume
 }
 
-func createVolumeWithState(state string) v1alpha1.Volume {
-	volume := createVolume(0, v1alpha1.VolumeParameters{
-		Name: dataVolume2Name,
-		Size: dataVolume2Size,
-		Type: dataVolume2Type,
-	})
+func createVolumeWithState(replicaIdx int, parameters v1alpha1.VolumeParameters, state string) v1alpha1.Volume {
+	volume := createVolume(replicaIdx, parameters)
 	volume.Status.AtProvider.State = state
 	return volume
 }
+
 func createVolume(replicaIdx int, parameters v1alpha1.VolumeParameters) v1alpha1.Volume {
 	withNameUpdated := parameters
 	withNameUpdated.Name = nameWithIdx(replicaIdx, parameters.Name)

--- a/internal/controller/compute/statefulserverset/objects_test.go
+++ b/internal/controller/compute/statefulserverset/objects_test.go
@@ -388,15 +388,24 @@ func createVolumeList() v1alpha1.VolumeList {
 		},
 	}
 }
-func createVolumeDefault() *v1alpha1.Volume {
+func createVolumeDefault() v1alpha1.Volume {
 	volume := createVolume(0, v1alpha1.VolumeParameters{
 		Name: dataVolume2Name,
 		Size: dataVolume2Size,
 		Type: dataVolume2Type,
 	})
-	return &volume
+	return volume
 }
 
+func createVolumeWithState(state string) v1alpha1.Volume {
+	volume := createVolume(0, v1alpha1.VolumeParameters{
+		Name: dataVolume2Name,
+		Size: dataVolume2Size,
+		Type: dataVolume2Type,
+	})
+	volume.Status.AtProvider.State = state
+	return volume
+}
 func createVolume(replicaIdx int, parameters v1alpha1.VolumeParameters) v1alpha1.Volume {
 	withNameUpdated := parameters
 	withNameUpdated.Name = nameWithIdx(replicaIdx, parameters.Name)

--- a/internal/controller/compute/statefulserverset/serverset_controller.go
+++ b/internal/controller/compute/statefulserverset/serverset_controller.go
@@ -49,7 +49,7 @@ func (k *kubeServerSetController) Update(ctx context.Context, cr *v1alpha1.State
 		return v1alpha1.ServerSet{}, err
 	}
 
-	areResUpToDate, err := areSSetResourcesUpToDate(ctx, k.kube, cr)
+	areResUpToDate, _, err := areSSetResourcesReady(ctx, k.kube, cr)
 	if err != nil {
 		return v1alpha1.ServerSet{}, err
 	}

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -393,10 +393,7 @@ func areDataVolumesUpToDateAndAvailable(cr *v1alpha1.StatefulServerSet, volumes 
 }
 
 func isAVolumeFieldNotUpToDate(specVolume v1alpha1.StatefulServerSetVolume, volumeIndex int, volumes []v1alpha1.Volume) bool {
-	if volumes[volumeIndex].Spec.ForProvider.Size != specVolume.Spec.Size {
-		return true
-	}
-	return false
+	return volumes[volumeIndex].Spec.ForProvider.Size != specVolume.Spec.Size
 }
 
 func areSSetResourcesReady(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (isSsetUpToDate, isSsetAvailable bool, err error) {

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -25,6 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/pkg/errors"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -108,12 +109,15 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	if meta.GetExternalName(cr) == "" {
 		return managed.ExternalObservation{}, nil
 	}
-	areResourcesCreated, areResourcesUpdated, err := e.observeResourcesUpdateStatus(ctx, cr)
+	areResourcesCreated, areResourcesUpdated, areResourcesAvailable, err := e.observeResourcesUpdateStatus(ctx, cr)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
-
-	cr.Status.SetConditions(xpv1.Available())
+	if areResourcesCreated && areResourcesUpdated && areResourcesAvailable {
+		cr.SetConditions(xpv1.Available())
+	} else {
+		cr.SetConditions(xpv1.Creating())
+	}
 
 	return managed.ExternalObservation{
 		// Return false when the externalStatefulServerSet resource does not exist. This lets
@@ -132,12 +136,12 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	}, nil
 }
 
-func (e *external) observeResourcesUpdateStatus(ctx context.Context, cr *v1alpha1.StatefulServerSet) (areResourcesCreated, areResourcesUpdated bool, err error) { // nolint:gocyclo
+func (e *external) observeResourcesUpdateStatus(ctx context.Context, cr *v1alpha1.StatefulServerSet) (areResourcesCreated, areResourcesUpdated, areResourcesAvailable bool, err error) { // nolint:gocyclo
 
 	// ******************* LANS *******************
 	lans, err := e.LANController.ListLans(ctx, cr)
 	if err != nil {
-		return false, false, fmt.Errorf("while listing lans %w", err)
+		return false, false, false, fmt.Errorf("while listing lans %w", err)
 	}
 	creationLansUpToDate, areLansUpToDate := areLansUpToDate(cr, lans.Items)
 	cr.Status.AtProvider.LanStatuses = computeLanStatuses(lans.Items)
@@ -145,44 +149,44 @@ func (e *external) observeResourcesUpdateStatus(ctx context.Context, cr *v1alpha
 	// ******************* VOLUMES *******************
 	volumes, err := e.dataVolumeController.ListVolumes(ctx, cr)
 	if err != nil {
-		return false, false, fmt.Errorf("while listing volumes %w", err)
+		return false, false, false, fmt.Errorf("while listing volumes %w", err)
 	}
-	creationVolumesUpToDate, areVolumesUpToDate := areDataVolumesUpToDate(cr, volumes.Items)
+	creationVolumesUpToDate, areVolumesUpToDate, areVolumesAvailable := areDataVolumesUpToDateAndAvailable(cr, volumes.Items)
 	cr.Status.AtProvider.DataVolumeStatuses = setVolumeStatuses(volumes.Items)
 
 	// ******************* SERVERSET *******************
-	creationServerSetUpToDate, isServerSetUpToDate, err := e.isServerSetUpToDate(ctx, cr)
+	creationServerSetUpToDate, isServerSetUpToDate, isSsetAvailable, err := e.isServerSetUpToDate(ctx, cr)
 	if err != nil {
-		return false, false, err
+		return false, false, false, err
 	}
 	err = e.setSSetStatusOnCR(ctx, cr)
 	if err != nil {
-		return false, false, err
+		return false, false, false, err
 	}
 
 	// ******************* VOLUMESELECTOR *******************
 	creationVSUpToDate, err := e.isVolumeSelectorUpToDate(ctx, cr)
 	if err != nil {
-		return false, false, err
+		return false, false, false, err
 	}
 	e.log.Info("Observing the StatefulServerSet", "creationLansUpToDate", creationLansUpToDate, "areLansUpToDate", areLansUpToDate, "creationVolumesUpToDate", creationVolumesUpToDate,
-		"areVolumesUpToDate", areVolumesUpToDate, "creationServerSetUpToDate", creationServerSetUpToDate, "isServerSetUpToDate", isServerSetUpToDate, "creationVSUpToDate", creationVSUpToDate)
+		"areVolumesUpToDate", areVolumesUpToDate, "creationServerSetUpToDate", creationServerSetUpToDate, "isServerSetUpToDate", isServerSetUpToDate, "creationVSUpToDate", creationVSUpToDate, "areVolumesAvailable", areVolumesAvailable)
 
-	return creationLansUpToDate && creationVolumesUpToDate && creationServerSetUpToDate && creationVSUpToDate, areLansUpToDate && areVolumesUpToDate && isServerSetUpToDate, nil
+	return creationLansUpToDate && creationVolumesUpToDate && creationServerSetUpToDate && creationVSUpToDate, areLansUpToDate && areVolumesUpToDate && isServerSetUpToDate, areVolumesAvailable && isSsetAvailable, nil
 }
 
-func (e *external) isServerSetUpToDate(ctx context.Context, cr *v1alpha1.StatefulServerSet) (creationServerUpToDate bool, serversetUpToDate bool, err error) {
+func (e *external) isServerSetUpToDate(ctx context.Context, cr *v1alpha1.StatefulServerSet) (creationServerUpToDate, serversetUpToDate, ssetAvailable bool, err error) {
 	_, err = e.SSetController.Get(ctx, getSSetName(cr), cr.Namespace)
 	if err != nil {
 		if apiErrors.IsNotFound(err) {
-			return false, false, nil
+			return false, false, false, nil
 		}
 	}
-	serversetUpToDate, err = areSSetResourcesUpToDate(ctx, e.kube, cr)
+	serversetUpToDate, ssetAvailable, err = areSSetResourcesReady(ctx, e.kube, cr)
 	if err != nil {
-		return false, false, err
+		return false, false, false, err
 	}
-	return true, serversetUpToDate, err
+	return true, serversetUpToDate, ssetAvailable, err
 }
 
 func (e *external) isVolumeSelectorUpToDate(ctx context.Context, cr *v1alpha1.StatefulServerSet) (creationVSUpToDate bool, err error) {
@@ -217,7 +221,7 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.New(errNotStatefulServerSet)
 	}
 
-	cr.Status.SetConditions(xpv1.Creating())
+	cr.SetConditions(xpv1.Creating())
 
 	e.log.Info("Creating a new StatefulServerSet", "name", cr.Name, "replicas", cr.Spec.ForProvider.Replicas)
 	for replicaIndex := 0; replicaIndex < cr.Spec.ForProvider.Replicas; replicaIndex++ {
@@ -368,19 +372,22 @@ func isALanFieldNotUpToDate(specLan v1alpha1.StatefulServerSetLan, gotLan v1alph
 	return false
 }
 
-func areDataVolumesUpToDate(cr *v1alpha1.StatefulServerSet, volumes []v1alpha1.Volume) (bool, bool) {
+func areDataVolumesUpToDateAndAvailable(cr *v1alpha1.StatefulServerSet, volumes []v1alpha1.Volume) (creationVolumesUpToDate, areVolumesUpToDate, volumesAvailable bool) {
 	crExpectedNrOfVolumes := len(cr.Spec.ForProvider.Volumes) * cr.Spec.ForProvider.Replicas
 	if len(volumes) != crExpectedNrOfVolumes {
-		return false, false
+		return false, false, false
 	}
 	for volumeIndex := range volumes {
 		for _, specVolume := range cr.Spec.ForProvider.Volumes {
 			if isAVolumeFieldNotUpToDate(specVolume, volumeIndex, volumes) {
-				return true, false
+				return true, false, false
+			}
+			if volumes[volumeIndex].Status.AtProvider.State != ionoscloud.Available {
+				return true, true, false
 			}
 		}
 	}
-	return true, true
+	return true, true, true
 }
 
 func isAVolumeFieldNotUpToDate(specVolume v1alpha1.StatefulServerSetVolume, volumeIndex int, volumes []v1alpha1.Volume) bool {
@@ -393,44 +400,45 @@ func isAVolumeFieldNotUpToDate(specVolume v1alpha1.StatefulServerSetVolume, volu
 	return false
 }
 
-func areSSetResourcesUpToDate(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (bool, error) {
-	areServersUpToDate, err := areServersUpToDate(ctx, kube, cr)
-	if !areServersUpToDate {
-		return false, err
+func areSSetResourcesReady(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (isSsetUpToDate, isSsetAvailable bool, err error) {
+	serversUpToDate, areServersAvailable, err := areServersUpToDate(ctx, kube, cr)
+	if !serversUpToDate {
+		return false, false, err
 	}
 
-	areBootVolumesUpToDate, err := areBootVolumesUpToDate(ctx, kube, cr)
-	if !areBootVolumesUpToDate {
-		return false, err
+	bootVolumesUpToDate, areBootVolumesAvailable, err := areBootVolumesUpToDate(ctx, kube, cr)
+	if !bootVolumesUpToDate {
+		return false, false, err
 	}
 
 	areNICSUpToDate, err := areNICsUpToDate(ctx, kube, cr)
 	if !areNICSUpToDate {
-		return false, err
+		return false, false, err
 	}
 
-	return true, nil
+	return true, areServersAvailable && areBootVolumesAvailable, nil
 }
 
-func areServersUpToDate(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (bool, error) {
+func areServersUpToDate(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (areServersUpToDate, areServersAvailable bool, err error) {
 	servers, err := serverset.GetServersOfSSet(ctx, kube, getSSetName(cr))
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 
 	if len(servers) < cr.Spec.ForProvider.Replicas {
-		return false, nil
+		return false, false, nil
 	}
-
-	return serverset.AreServersUpToDate(cr.Spec.ForProvider.Template.Spec, servers), nil
+	areServersUpToDate, areServersAvailable = serverset.AreServersReady(cr.Spec.ForProvider.Template.Spec, servers)
+	return areServersUpToDate, areServersAvailable, nil
 }
 
-func areBootVolumesUpToDate(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (bool, error) {
+func areBootVolumesUpToDate(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (areUpToDate, areAvailable bool, err error) {
 	volumes, err := serverset.GetVolumesOfSSet(ctx, kube, getSSetName(cr))
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
-	return serverset.AreVolumesUpToDate(cr.Spec.ForProvider.BootVolumeTemplate, volumes), nil
+	areUpToDate, areAvailable = serverset.AreVolumesReady(cr.Spec.ForProvider.BootVolumeTemplate, volumes)
+	return areUpToDate, areAvailable, nil
 }
 
 func areNICsUpToDate(ctx context.Context, kube client.Client, cr *v1alpha1.StatefulServerSet) (bool, error) {

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -391,9 +391,6 @@ func areDataVolumesUpToDateAndAvailable(cr *v1alpha1.StatefulServerSet, volumes 
 }
 
 func isAVolumeFieldNotUpToDate(specVolume v1alpha1.StatefulServerSetVolume, volumeIndex int, volumes []v1alpha1.Volume) bool {
-	if generateProviderNameFromIndex(specVolume.Metadata.Name, volumeIndex) != volumes[volumeIndex].Spec.ForProvider.Name {
-		return false
-	}
 	if volumes[volumeIndex].Spec.ForProvider.Size != specVolume.Spec.Size {
 		return true
 	}

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -143,7 +143,7 @@ func (e *external) observeResourcesUpdateStatus(ctx context.Context, cr *v1alpha
 	if err != nil {
 		return false, false, false, fmt.Errorf("while listing lans %w", err)
 	}
-	creationLansUpToDate, areLansUpToDate := areLansUpToDate(cr, lans.Items)
+	creationLansUpToDate, lansUpToDate := areLansUpToDate(cr, lans.Items)
 	cr.Status.AtProvider.LanStatuses = computeLanStatuses(lans.Items)
 
 	// ******************* VOLUMES *******************
@@ -155,7 +155,7 @@ func (e *external) observeResourcesUpdateStatus(ctx context.Context, cr *v1alpha
 	cr.Status.AtProvider.DataVolumeStatuses = setVolumeStatuses(volumes.Items)
 
 	// ******************* SERVERSET *******************
-	creationServerSetUpToDate, isServerSetUpToDate, isSsetAvailable, err := e.isServerSetUpToDate(ctx, cr)
+	creationSSetUpToDate, isSSetUpToDate, isSSetAvailable, err := e.isServerSetUpToDate(ctx, cr)
 	if err != nil {
 		return false, false, false, err
 	}
@@ -169,10 +169,12 @@ func (e *external) observeResourcesUpdateStatus(ctx context.Context, cr *v1alpha
 	if err != nil {
 		return false, false, false, err
 	}
-	e.log.Info("Observing the StatefulServerSet", "creationLansUpToDate", creationLansUpToDate, "areLansUpToDate", areLansUpToDate, "creationVolumesUpToDate", creationVolumesUpToDate,
-		"areVolumesUpToDate", areVolumesUpToDate, "creationServerSetUpToDate", creationServerSetUpToDate, "isServerSetUpToDate", isServerSetUpToDate, "creationVSUpToDate", creationVSUpToDate, "areVolumesAvailable", areVolumesAvailable)
-
-	return creationLansUpToDate && creationVolumesUpToDate && creationServerSetUpToDate && creationVSUpToDate, areLansUpToDate && areVolumesUpToDate && isServerSetUpToDate, areVolumesAvailable && isSsetAvailable, nil
+	e.log.Info("Observing the StatefulServerSet", "creationLansUpToDate", creationLansUpToDate, "lansUpToDate", lansUpToDate, "creationVolumesUpToDate", creationVolumesUpToDate,
+		"areVolumesUpToDate", areVolumesUpToDate, "creationSSetUpToDate", creationSSetUpToDate, "isSSetUpToDate", isSSetUpToDate, "creationVSUpToDate", creationVSUpToDate, "areVolumesAvailable", areVolumesAvailable)
+	areResourcesCreated = creationLansUpToDate && creationVolumesUpToDate && creationSSetUpToDate && creationVSUpToDate
+	areResourcesUpdated = lansUpToDate && areVolumesUpToDate && isSSetUpToDate
+	areResourcesAvailable = areVolumesAvailable && isSSetAvailable
+	return areResourcesCreated, areResourcesUpdated, areResourcesAvailable, nil
 }
 
 func (e *external) isServerSetUpToDate(ctx context.Context, cr *v1alpha1.StatefulServerSet) (creationServerUpToDate, serversetUpToDate, ssetAvailable bool, err error) {

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -433,7 +433,7 @@ func areBootVolumesUpToDate(ctx context.Context, kube client.Client, cr *v1alpha
 	if err != nil {
 		return false, false, err
 	}
-	areUpToDate, areAvailable = serverset.AreVolumesReady(cr.Spec.ForProvider.BootVolumeTemplate, volumes)
+	areUpToDate, areAvailable = serverset.AreBootVolumesReady(cr.Spec.ForProvider.BootVolumeTemplate, volumes)
 	return areUpToDate, areAvailable, nil
 }
 

--- a/internal/controller/compute/statefulserverset/statefulserverset_test.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset_test.go
@@ -504,13 +504,55 @@ func Test_areDataVolumesUpToDate(t *testing.T) {
 			},
 		},
 		{
-			name:    "Data Volumes ready, uptodate and available",
-			sSSet:   createSSSet(),
-			volumes: []v1alpha1.Volume{createVolumeWithState(ionoscloud.Available), createVolumeWithState(ionoscloud.Available), createVolumeWithState(ionoscloud.Available), createVolumeWithState(ionoscloud.Available)},
+			name:  "Data Volumes ready, uptodate and not available",
+			sSSet: createSSSet(),
+			volumes: []v1alpha1.Volume{createVolumeWithState(0, v1alpha1.VolumeParameters{
+				Name: dataVolume1Name,
+				Size: dataVolume1Size,
+				Type: dataVolume1Type,
+			}, ionoscloud.Available), createVolumeWithState(0, v1alpha1.VolumeParameters{
+				Name: dataVolume1Name,
+				Size: dataVolume1Size,
+				Type: dataVolume1Type,
+			}, ionoscloud.Available), createVolumeWithState(1, v1alpha1.VolumeParameters{
+				Name: dataVolume2Name,
+				Size: dataVolume2Size,
+				Type: dataVolume2Type,
+			}, ionoscloud.Available), createVolumeWithState(1, v1alpha1.VolumeParameters{
+				Name: dataVolume2Name,
+				Size: dataVolume2Size,
+				Type: dataVolume2Type,
+			}, ionoscloud.Busy)},
 			want: want{
 				creationUpToDate: true,
 				areUpToDate:      true,
-				areAvailable:     true,
+				areAvailable:     false,
+			},
+		},
+		{
+			name:  "Data Volumes ready, not uptodate and available",
+			sSSet: createSSSet(),
+			volumes: []v1alpha1.Volume{createVolumeWithState(0, v1alpha1.VolumeParameters{
+				Name: dataVolume1Name,
+				Size: dataVolume1Size,
+				Type: dataVolume1Type,
+			}, ionoscloud.Available), createVolumeWithState(0, v1alpha1.VolumeParameters{
+				Name: dataVolume1Name,
+				Size: dataVolume1Size,
+				Type: dataVolume1Type,
+			}, ionoscloud.Available), createVolumeWithState(1, v1alpha1.VolumeParameters{
+				Name: dataVolume1Name,
+				Size: dataVolume1Size,
+				Type: dataVolume1Type,
+			}, ionoscloud.Available), createVolumeWithState(0, v1alpha1.VolumeParameters{
+				Name: dataVolume1Name,
+				Size: 20,
+				Type: dataVolume1Type,
+			}, ionoscloud.Available)},
+			want: want{
+				creationUpToDate: true,
+				areUpToDate:      false,
+				areAvailable:     false,
 			},
 		},
 	}
@@ -518,9 +560,9 @@ func Test_areDataVolumesUpToDate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			creationUpToDate, areUpToDate, areAvailable := areDataVolumesUpToDateAndAvailable(tt.sSSet, tt.volumes)
-			assert.Equal(t, tt.want.creationUpToDate, creationUpToDate)
-			assert.Equal(t, tt.want.areUpToDate, areUpToDate)
-			assert.Equal(t, tt.want.areAvailable, areAvailable)
+			assert.Equalf(t, tt.want.creationUpToDate, creationUpToDate, "creationUpToDate is not equal")
+			assert.Equal(t, tt.want.areUpToDate, areUpToDate, "areUpToDate is not equal")
+			assert.Equal(t, tt.want.areAvailable, areAvailable, "areAvailable is not equal")
 		})
 	}
 }

--- a/internal/controller/compute/statefulserverset/statefulserverset_test.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset_test.go
@@ -453,6 +453,7 @@ func Test_areDataVolumesUpToDate(t *testing.T) {
 	type want = struct {
 		creationUpToDate bool
 		areUpToDate      bool
+		areAvailable     bool
 	}
 
 	tests := []struct {
@@ -468,6 +469,7 @@ func Test_areDataVolumesUpToDate(t *testing.T) {
 			want: want{
 				creationUpToDate: false,
 				areUpToDate:      false,
+				areAvailable:     false,
 			},
 		},
 		{
@@ -477,6 +479,7 @@ func Test_areDataVolumesUpToDate(t *testing.T) {
 			want: want{
 				creationUpToDate: false,
 				areUpToDate:      false,
+				areAvailable:     false,
 			},
 		},
 		{
@@ -486,15 +489,17 @@ func Test_areDataVolumesUpToDate(t *testing.T) {
 			want: want{
 				creationUpToDate: false,
 				areUpToDate:      false,
+				areAvailable:     false,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			creationUpToDate, areUpToDate := areDataVolumesUpToDate(tt.sSSet, tt.lans)
+			creationUpToDate, areUpToDate, areAvailable := areDataVolumesUpToDateAndAvailable(tt.sSSet, tt.lans)
 			assert.Equal(t, tt.want.creationUpToDate, creationUpToDate)
 			assert.Equal(t, tt.want.areUpToDate, areUpToDate)
+			assert.Equal(t, tt.want.areAvailable, areAvailable)
 		})
 	}
 }

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -116,14 +116,14 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	e.populateReplicasStatuses(ctx, cr, servers)
 
 	areServersCreated := len(servers) == cr.Spec.ForProvider.Replicas
-	areServersUpToDate := AreServersUpToDate(cr.Spec.ForProvider.Template.Spec, servers)
+	areServersUpToDate, areServersAvailable := AreServersReady(cr.Spec.ForProvider.Template.Spec, servers)
 
 	volumes, err := GetVolumesOfSSet(ctx, e.kube, cr.Name)
 	if err != nil {
 		return managed.ExternalObservation{}, err
 	}
 	areBootVolumesCreated := len(volumes) == cr.Spec.ForProvider.Replicas
-	areBootVolumesUpToDate := AreVolumesUpToDate(cr.Spec.ForProvider.BootVolumeTemplate, volumes)
+	areBootVolumesUpToDate, areBootVolumesAvailable := AreVolumesReady(cr.Spec.ForProvider.BootVolumeTemplate, volumes)
 
 	nics, err := GetNICsOfSSet(ctx, e.kube, cr.Name)
 	if err != nil {
@@ -133,9 +133,13 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	areNICsCreated := len(nics) == crExpectedNoOfNICs
 
 	// at the moment we do not check that fields of nics are updated, because nic fields are immutable
-	e.log.Info("Observing the ServerSet", "areServersUpToDate", areServersUpToDate, "areBootVolumesUpToDate", areBootVolumesUpToDate, "areServersCreated", areServersCreated, "areBootVolumesCreated", areBootVolumesCreated, "areNICsCreated", areNICsCreated)
-
-	cr.SetConditions(xpv1.Available())
+	e.log.Info("Observing the ServerSet", "areServersUpToDate", areServersUpToDate, "areBootVolumesUpToDate", areBootVolumesUpToDate, "areServersCreated",
+		areServersCreated, "areBootVolumesCreated", areBootVolumesCreated, "areNICsCreated", areNICsCreated, "areServersAvailable", areServersAvailable, "areBootVolumesAvailable", areBootVolumesAvailable)
+	if areServersAvailable && areBootVolumesAvailable {
+		cr.SetConditions(xpv1.Available())
+	} else {
+		cr.SetConditions(xpv1.Creating())
+	}
 
 	return managed.ExternalObservation{
 		// Return false when the externalServerSet resource does not exist. This lets
@@ -467,38 +471,44 @@ func (e *external) Delete(ctx context.Context, mg resource.Managed) error {
 	return nil
 }
 
-// AreServersUpToDate checks if replicas and template params are equal to server obj params
-func AreServersUpToDate(templateParams v1alpha1.ServerSetTemplateSpec, servers []v1alpha1.Server) bool {
+// AreServersReady checks if replicas and template params are equal to server obj params
+func AreServersReady(templateParams v1alpha1.ServerSetTemplateSpec, servers []v1alpha1.Server) (areServersUpToDate, areServersAvailable bool) {
 	for _, serverObj := range servers {
 		if serverObj.Spec.ForProvider.Cores != templateParams.Cores {
-			return false
+			return false, false
 		}
 		if serverObj.Spec.ForProvider.RAM != templateParams.RAM {
-			return false
+			return false, false
 		}
 		if serverObj.Spec.ForProvider.CPUFamily != templateParams.CPUFamily {
-			return false
+			return false, false
+		}
+		if serverObj.Status.AtProvider.State != ionoscloud.Available {
+			return true, false
 		}
 	}
 
-	return true
+	return true, true
 }
 
-// AreVolumesUpToDate checks if template params are equal to volume obj params
-func AreVolumesUpToDate(templateParams v1alpha1.BootVolumeTemplate, volumes []v1alpha1.Volume) bool {
+// AreVolumesReady checks if template params are equal to volume obj params
+func AreVolumesReady(templateParams v1alpha1.BootVolumeTemplate, volumes []v1alpha1.Volume) (bool, bool) {
 	for _, volumeObj := range volumes {
 		if volumeObj.Spec.ForProvider.Size != templateParams.Spec.Size {
-			return false
+			return false, false
 		}
 		if volumeObj.Spec.ForProvider.Image != templateParams.Spec.Image {
-			return false
+			return false, false
 		}
 		if volumeObj.Spec.ForProvider.Type != templateParams.Spec.Type {
-			return false
+			return false, false
+		}
+		if volumeObj.Status.AtProvider.State != ionoscloud.Available {
+			return true, false
 		}
 	}
 
-	return true
+	return true, true
 }
 
 // GetServersOfSSet - gets servers from a server set based on the ionoscloud.com/serverset label

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -98,7 +98,7 @@ type external struct {
 	log                  logging.Logger
 }
 
-func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
+func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) { // nolint:gocyclo
 	cr, ok := mg.(*v1alpha1.ServerSet)
 	if !ok {
 		return managed.ExternalObservation{}, errors.New(errUnexpectedObject)

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -123,7 +123,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, err
 	}
 	areBootVolumesCreated := len(volumes) == cr.Spec.ForProvider.Replicas
-	areBootVolumesUpToDate, areBootVolumesAvailable := AreVolumesReady(cr.Spec.ForProvider.BootVolumeTemplate, volumes)
+	areBootVolumesUpToDate, areBootVolumesAvailable := AreBootVolumesReady(cr.Spec.ForProvider.BootVolumeTemplate, volumes)
 
 	nics, err := GetNICsOfSSet(ctx, e.kube, cr.Name)
 	if err != nil {
@@ -491,8 +491,8 @@ func AreServersReady(templateParams v1alpha1.ServerSetTemplateSpec, servers []v1
 	return true, true
 }
 
-// AreVolumesReady checks if template params are equal to volume obj params
-func AreVolumesReady(templateParams v1alpha1.BootVolumeTemplate, volumes []v1alpha1.Volume) (bool, bool) {
+// AreBootVolumesReady checks if template params are equal to volume obj params
+func AreBootVolumesReady(templateParams v1alpha1.BootVolumeTemplate, volumes []v1alpha1.Volume) (bool, bool) {
 	for _, volumeObj := range volumes {
 		if volumeObj.Spec.ForProvider.Size != templateParams.Spec.Size {
 			return false, false


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes
When the ssset needs to update it should reflect this in it's state/status. This means that it needs to get updates from servers and volumes.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
