### PR TITLE
feat: add datacenterId field to node pool lan

### DIFF
--- a/apis/k8s/v1alpha1/nodepool_types.go
+++ b/apis/k8s/v1alpha1/nodepool_types.go
@@ -162,6 +162,10 @@ type KubernetesNodePoolLan struct {
 	//
 	// +kubebuilder:validation:Optional
 	Routes []KubernetesNodePoolLanRoutes `json:"routes,omitempty"`
+	// The datacenter ID, requires system privileges, for internal usage only
+	//
+	// +kubebuilder:validation:Optional
+	DatacenterID string `json:"datacenterID,omitempty"`
 }
 
 // KubernetesNodePoolLanRoutes struct for KubernetesNodePoolLanRoutes.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.0.13] (TBD)
+- **Features**:
+    - Add `datacenterID` field for node pool lan in k8s `NodePool` CRD managed resources:
+
+- **Misc**:
+    - Use builtin `controller.Options` in controller setup functions
+
 ## [1.0.12] (May 2024)
 - **Fixes**:
     - Fixes for `MongoUser` and `PostgresUser`:

--- a/internal/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/clients/k8s/k8snodepool/nodepool.go
@@ -318,8 +318,9 @@ func kubernetesNodePoolLans(crLans []v1alpha1.KubernetesNodePoolLan) *[]sdkgo.Ku
 			lanIDConverted, _ := strconv.ParseInt(crLan.LanCfg.LanID, 10, 64)
 			lanID := int32(lanIDConverted)
 			newNodePoolLan := sdkgo.KubernetesNodePoolLan{
-				Id:   &lanID,
-				Dhcp: &crLan.Dhcp,
+				Id:           &lanID,
+				Dhcp:         &crLan.Dhcp,
+				DatacenterId: &crLan.DatacenterID,
 			}
 			if len(crLan.Routes) > 0 {
 				routes := make([]sdkgo.KubernetesNodePoolLanRoutes, 0)
@@ -356,6 +357,9 @@ func isEqKubernetesNodePoolLans(crLans []v1alpha1.KubernetesNodePoolLan, lans []
 		}
 		lanIDConverted, _ := strconv.ParseInt(crLan.LanCfg.LanID, 10, 64)
 		if lan.Id != nil && *lan.Id != int32(lanIDConverted) {
+			return false
+		}
+		if lan.DatacenterId != nil && *lan.DatacenterId != crLan.DatacenterID {
 			return false
 		}
 		for j, crRoute := range crLan.Routes {

--- a/package/crds/k8s.ionoscloud.crossplane.io_nodepools.yaml
+++ b/package/crds/k8s.ionoscloud.crossplane.io_nodepools.yaml
@@ -334,6 +334,10 @@ spec:
                     items:
                       description: KubernetesNodePoolLan struct for KubernetesNodePoolLan.
                       properties:
+                        datacenterID:
+                          description: // The datacenter ID, requires system privileges,
+                            for internal usage only
+                          type: string
                         dhcp:
                           description: Indicates if the Kubernetes NodePool LAN will
                             reserve an IP using DHCP.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:
Adds the `datacenterID` field to the k8s NodePool CRD
## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
