### PR TITLE
Fix: add missing ipv6 nic property

### DIFF
--- a/internal/clients/compute/nic/nic.go
+++ b/internal/clients/compute/nic/nic.go
@@ -3,11 +3,11 @@ package nic
 import (
 	"context"
 	"fmt"
+	"net"
 	"reflect"
 
-	"github.com/rung/go-safecast"
-
 	sdkgo "github.com/ionos-cloud/sdk-go/v6"
+	"github.com/rung/go-safecast"
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients"
@@ -164,7 +164,13 @@ func GenerateUpdateNicInput(cr *v1alpha1.Nic, ips []string) (*sdkgo.NicPropertie
 		instanceUpdateInput.SetName(cr.Spec.ForProvider.Name)
 	}
 	if len(ips) > 0 {
-		instanceUpdateInput.SetIps(ips)
+		ipv4s, ipv6s := GetIPvSlices(ips)
+		if len(ipv4s) > 0 {
+			instanceUpdateInput.SetIps(ips)
+		}
+		if len(ipv6s) > 0 {
+			instanceUpdateInput.SetIpv6Ips(ips)
+		}
 	}
 	if cr.Spec.ForProvider.FirewallType != "" {
 		instanceUpdateInput.SetFirewallType(cr.Spec.ForProvider.FirewallType)
@@ -178,6 +184,13 @@ func GenerateUpdateNicInput(cr *v1alpha1.Nic, ips []string) (*sdkgo.NicPropertie
 
 // IsNicUpToDate returns true if the Nic is up-to-date or false if it does not
 func IsNicUpToDate(cr *v1alpha1.Nic, nic sdkgo.Nic, ips []string) bool { // nolint:gocyclo
+	var ipv4s []string
+	var ipv6s []string
+
+	if len(ips) > 0 {
+		ipv4s, ipv6s = GetIPvSlices(ips)
+	}
+
 	switch {
 	case cr == nil && nic.Properties == nil:
 		return true
@@ -201,9 +214,29 @@ func IsNicUpToDate(cr *v1alpha1.Nic, nic sdkgo.Nic, ips []string) bool { // noli
 		return false
 	case nic.Properties.Vnet != nil && *nic.Properties.Vnet != cr.Spec.ForProvider.Vnet:
 		return false
-	case len(ips) != 0 && nic.Properties.HasIps() && !utils.ContainsStringSlices(ips, *nic.Properties.Ips):
+	case len(ipv4s) != 0 && nic.Properties.HasIps() && !utils.ContainsStringSlices(ipv4s, *nic.Properties.Ips):
+		return false
+	case len(ipv6s) != 0 && nic.Properties.HasIpv6Ips() && !utils.ContainsStringSlices(ipv6s, *nic.Properties.Ipv6Ips):
 		return false
 	default:
 		return true
 	}
+}
+
+// GetIPvSlices splits ips into ipv4 / ipv6 slices
+func GetIPvSlices(ips []string) (ipv4s []string, ipv6s []string) {
+	for _, ip := range ips {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP == nil {
+			continue
+		}
+
+		if parsedIP.To4() != nil {
+			ipv4s = append(ipv4s, ip)
+		} else {
+			ipv6s = append(ipv6s, ip)
+		}
+	}
+
+	return ipv4s, ipv6s
 }

--- a/internal/clients/compute/nic/nic_test.go
+++ b/internal/clients/compute/nic/nic_test.go
@@ -4,10 +4,9 @@ import (
 	"testing"
 
 	"github.com/ionos-cloud/sdk-go-bundle/shared"
+	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
-
-	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 )
 
 func TestIsNicUpToDate(t *testing.T) {
@@ -73,7 +72,8 @@ func TestIsNicUpToDate(t *testing.T) {
 						FirewallActive: shared.ToPtr(false),
 						FirewallType:   shared.ToPtr("INGRESS"),
 						Vnet:           shared.ToPtr("1"),
-					}},
+					},
+				},
 			},
 			want: true,
 		},
@@ -140,7 +140,8 @@ func TestIsNicUpToDate(t *testing.T) {
 					},
 					Properties: &ionoscloud.NicProperties{
 						Name: shared.ToPtr("empty"),
-					}},
+					},
+				},
 			},
 			want: true,
 		},
@@ -155,6 +156,7 @@ func TestIsNicUpToDate(t *testing.T) {
 								IPs: []string{
 									"10.10.10.10",
 									"10.10.10.11",
+									"2001:0db8:85a3::8a2e:0370:7335",
 								},
 							},
 						},
@@ -164,6 +166,7 @@ func TestIsNicUpToDate(t *testing.T) {
 				ips: []string{
 					"10.10.10.10",
 					"10.10.10.11",
+					"2001:0db8:85a3::8a2e:0370:7335",
 				},
 				Nic: ionoscloud.Nic{
 					Properties: &ionoscloud.NicProperties{
@@ -172,7 +175,11 @@ func TestIsNicUpToDate(t *testing.T) {
 							"10.11.12.13",
 							"192.168.8.14",
 						},
-					}},
+						Ipv6Ips: &[]string{
+							"2001:0db8:85a3::8a2e:0370:7334",
+						},
+					},
+				},
 			},
 			want: false,
 		},
@@ -187,6 +194,7 @@ func TestIsNicUpToDate(t *testing.T) {
 								IPs: []string{
 									"10.10.10.10",
 									"10.10.10.11",
+									"2001:0db8:85a3::8a2e:0370:7335",
 								},
 							},
 						},
@@ -196,6 +204,7 @@ func TestIsNicUpToDate(t *testing.T) {
 				ips: []string{
 					"10.10.10.10",
 					"10.10.10.11",
+					"2001:0db8:85a3::8a2e:0370:7335",
 				},
 				Nic: ionoscloud.Nic{
 					Properties: &ionoscloud.NicProperties{
@@ -204,7 +213,11 @@ func TestIsNicUpToDate(t *testing.T) {
 							"10.10.10.10",
 							"10.10.10.11",
 						},
-					}},
+						Ipv6Ips: &[]string{
+							"2001:0db8:85a3::8a2e:0370:7335",
+						},
+					},
+				},
 			},
 			want: true,
 		},
@@ -221,7 +234,8 @@ func TestIsNicUpToDate(t *testing.T) {
 				Nic: ionoscloud.Nic{
 					Properties: &ionoscloud.NicProperties{
 						Dhcpv6: nil,
-					}},
+					},
+				},
 			},
 			want: true,
 		},
@@ -238,7 +252,8 @@ func TestIsNicUpToDate(t *testing.T) {
 				Nic: ionoscloud.Nic{
 					Properties: &ionoscloud.NicProperties{
 						Dhcpv6: ionoscloud.PtrBool(true),
-					}},
+					},
+				},
 			},
 			want: true,
 		},
@@ -255,7 +270,8 @@ func TestIsNicUpToDate(t *testing.T) {
 				Nic: ionoscloud.Nic{
 					Properties: &ionoscloud.NicProperties{
 						Dhcpv6: nil,
-					}},
+					},
+				},
 			},
 			want: true,
 		},
@@ -272,7 +288,8 @@ func TestIsNicUpToDate(t *testing.T) {
 				Nic: ionoscloud.Nic{
 					Properties: &ionoscloud.NicProperties{
 						Dhcpv6: ionoscloud.PtrBool(true),
-					}},
+					},
+				},
 			},
 			want: true,
 		},
@@ -289,7 +306,8 @@ func TestIsNicUpToDate(t *testing.T) {
 				Nic: ionoscloud.Nic{
 					Properties: &ionoscloud.NicProperties{
 						Dhcpv6: ionoscloud.PtrBool(true),
-					}},
+					},
+				},
 			},
 			want: false,
 		},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

Added missing ipv6 NIC property as document in https://api.ionos.com/docs/cloud/v6/#tag/Network-interfaces/operation/datacentersServersNicsPost

No changes in the CRD are required as ips are internally converted to ipv4 (ips) / ipv6 (ipv6Ips) fields required by the cloud API.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
