### PR TITLE
fix: use INTEL_ICELAKE for compute e2e tests

### DIFF
--- a/cluster/local/integration_tests_compute.sh
+++ b/cluster/local/integration_tests_compute.sh
@@ -321,7 +321,7 @@ spec:
     cores: 4
     ram: 2048
     availabilityZone: AUTO
-    cpuFamily: INTEL_XEON
+    cpuFamiliy: INTEL_ICELAKE
     datacenterConfig:
       datacenterIdRef:
         name: example
@@ -359,7 +359,7 @@ spec:
     cores: 4
     ram: 2048
     availabilityZone: AUTO
-    cpuFamily: INTEL_XEON
+    cpuFamiliy: INTEL_ICELAKE
     datacenterConfig:
       datacenterIdRef:
         name: example
@@ -395,7 +395,7 @@ spec:
     cores: 4
     ram: 2048
     availabilityZone: AUTO
-    cpuFamily: INTEL_XEON
+    cpuFamiliy: INTEL_ICELAKE
     datacenterConfig:
       datacenterIdRef:
         name: example

--- a/cluster/local/integration_tests_compute.sh
+++ b/cluster/local/integration_tests_compute.sh
@@ -321,7 +321,7 @@ spec:
     cores: 4
     ram: 2048
     availabilityZone: AUTO
-    cpuFamiliy: INTEL_ICELAKE
+    cpuFamily: INTEL_ICELAKE
     datacenterConfig:
       datacenterIdRef:
         name: example
@@ -359,7 +359,7 @@ spec:
     cores: 4
     ram: 2048
     availabilityZone: AUTO
-    cpuFamiliy: INTEL_ICELAKE
+    cpuFamily: INTEL_ICELAKE
     datacenterConfig:
       datacenterIdRef:
         name: example
@@ -395,7 +395,7 @@ spec:
     cores: 4
     ram: 2048
     availabilityZone: AUTO
-    cpuFamiliy: INTEL_ICELAKE
+    cpuFamily: INTEL_ICELAKE
     datacenterConfig:
       datacenterIdRef:
         name: example

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,14 @@
-## [1.1.3] (TBD)
+## [1.1.3]
 - **Features**:
     - Enable `publishConnectionDetails` option for s3 key, compute user and k8s clusters
+- **Misc**:
+    - Removed enum validation for `cpuFamily` fields.
+
+## [1.1.2]
+- **Features**:
+    - Connection pooler for psql, switch to sdk-go-bundle for postgres
+- **Fixes**:
+    - Add missing ipv6 property for nic
 
 ## [1.1.1] (July 2024)
 - **Fixes**:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->
 INTEL_XEON no longer supported in de/fra
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
