### PR TITLE
fix(server setup): Added MaxConcurrentReconciles to server manager setup

### DIFF
--- a/internal/controller/compute/server/server.go
+++ b/internal/controller/compute/server/server.go
@@ -27,13 +27,11 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
-	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
@@ -54,10 +52,7 @@ func Setup(mgr ctrl.Manager, opts *utils.ConfigurationOptions) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
-		WithOptions(controller.Options{
-			MaxConcurrentReconciles: opts.CtrlOpts.MaxConcurrentReconciles,
-			RateLimiter:             ratelimiter.NewController(),
-		}).
+		WithOptions(opts.CtrlOpts.ForControllerRuntime()).
 		For(&v1alpha1.Server{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1alpha1.ServerGroupVersionKind),

--- a/internal/controller/compute/server/server.go
+++ b/internal/controller/compute/server/server.go
@@ -55,7 +55,8 @@ func Setup(mgr ctrl.Manager, opts *utils.ConfigurationOptions) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithOptions(controller.Options{
-			RateLimiter: ratelimiter.NewController(),
+			MaxConcurrentReconciles: opts.CtrlOpts.MaxConcurrentReconciles,
+			RateLimiter:             ratelimiter.NewController(),
 		}).
 		For(&v1alpha1.Server{}).
 		Complete(managed.NewReconciler(mgr,


### PR DESCRIPTION
### Description of your changes

I noticed that despite increasing the max-reconcile-rate flag the number of workers assigned to each resource was remaining at 1, and that the max-reconcile-rate was only actually being used to adjust the GlobalRateLimiter (relevant P.S below). This also appears to be the case for all the other resources as well but I haven't been having scaling problems with those resources so didn't wish to over complicate the PR.

P.S I don't think the global rate limiter is being used either as the line underneath the one this PR adds just instantiates a new rate limiter with default settings)

This PR adds:

## Checklist

Minor code change that requires no documentation / test changes

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
