### PR TITLE
fix: write kubeconfig if not in deploying

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
+## [1.1.7]
+### Fixes:
+- Write kubeconfig to k8s cluster, only if not in deploying state.
+
 ## [1.1.6]
-- **Chore**:
+### Chore
 - Update crossplane-runtime to 1.18.0
 
 ## [1.1.4]

--- a/internal/controller/k8s/k8scluster/cluster.go
+++ b/internal/controller/k8s/k8scluster/cluster.go
@@ -155,8 +155,8 @@ func (c *externalCluster) Observe(ctx context.Context, mg resource.Managed) (man
 		if kubeconfig, _, err = c.service.GetKubeConfig(ctx, cr.Status.AtProvider.ClusterID); err != nil {
 			c.log.Info(fmt.Sprintf("failed to get connection details. error: %v", err))
 		}
+		mo.ConnectionDetails = createKubernetesConnectionDetails(c, kubeconfig, mg)
 	}
-	mo.ConnectionDetails = createKubernetesConnectionDetails(c, kubeconfig, mg)
 
 	return mo, nil
 }

--- a/internal/controller/k8s/k8scluster/cluster_test.go
+++ b/internal/controller/k8s/k8scluster/cluster_test.go
@@ -345,7 +345,6 @@ func TestExternalControlPlaneClientObserve(t *testing.T) {
 				ResourceExists:          true,
 				ResourceUpToDate:        true,
 				ResourceLateInitialized: false,
-				ConnectionDetails:       managed.ConnectionDetails{"kubeconfig": []byte("")},
 				Diff:                    "",
 			},
 			wantErr: false,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
