### PR TITLE
fix: s3 key stuck in creation loop after resource external delete

### DIFF
--- a/apis/compute/v1alpha1/s3key_types.go
+++ b/apis/compute/v1alpha1/s3key_types.go
@@ -20,7 +20,7 @@ type S3KeyParameters struct {
 	// Whether the IONOS Object Storage is active / enabled or not. Can only be updated to false, by default the key will be created as active. Default value is true.
 	//
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:validation:default=true
+	// +kubebuilder:default=true
 	Active bool `json:"active,omitempty"`
 }
 

--- a/internal/clients/compute/s3key/s3key.go
+++ b/internal/clients/compute/s3key/s3key.go
@@ -47,9 +47,7 @@ func IsS3KeyUpToDate(cr *v1alpha1.S3Key, s3Key sdkgo.S3Key) bool { // nolint:goc
 	switch {
 	case s3Key.Properties == nil:
 		return true
-	case s3Key.Properties != nil:
-		return false
-	case s3Key.Properties.Active == nil && cr.Spec.ForProvider.Active != *s3Key.Properties.Active:
+	case s3Key.Properties.Active != nil && cr.Spec.ForProvider.Active != *s3Key.Properties.Active:
 		return false
 	default:
 		return true

--- a/internal/controller/compute/s3key/s3Key.go
+++ b/internal/controller/compute/s3key/s3Key.go
@@ -103,7 +103,8 @@ func (c *connectorS3Key) Connect(ctx context.Context, mg resource.Managed) (mana
 	svc, err := clients.ConnectForCRD(ctx, mg, c.kube, c.usage)
 	return &externalS3Key{
 		service: s3key.APIClient{IonosServices: svc},
-		log:     c.log}, err
+		log:     c.log,
+	}, err
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -125,7 +126,7 @@ func (c *externalS3Key) Observe(ctx context.Context, mg resource.Managed) (manag
 	if meta.GetExternalName(cr) == "" {
 		return managed.ExternalObservation{}, nil
 	}
-	observed, apiResponse, err := c.service.GetS3Key(ctx, cr.Spec.ForProvider.UserID, cr.Status.AtProvider.S3KeyID)
+	observed, apiResponse, err := c.service.GetS3Key(ctx, cr.Spec.ForProvider.UserID, meta.GetExternalName(cr))
 	if err != nil {
 		retErr := fmt.Errorf("failed to get S3Key by id. error: %w", err)
 		// we get a 422 error response on key not found instead of 404

--- a/package/crds/compute.ionoscloud.crossplane.io_s3keys.yaml
+++ b/package/crds/compute.ionoscloud.crossplane.io_s3keys.yaml
@@ -78,6 +78,7 @@ spec:
                   UserID
                 properties:
                   active:
+                    default: true
                     description: Whether the IONOS Object Storage is active / enabled
                       or not. Can only be updated to false, by default the key will
                       be created as active. Default value is true.


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fix for https://github.com/ionos-cloud/crossplane-provider-ionoscloud/issues/288

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
