### PR TITLE
Fix: unpredictable ssset creation and deletion behavior due to root ctx expiring

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -56,7 +56,7 @@ func main() {
 		leaderElection    = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
 		createGracePeriod = app.Flag("create-grace-period", "Grace period for creation of IONOS Cloud resources.").Default("1m").Duration()
 		maxReconcileRate  = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("1").Int()
-		timeout           = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("4h").Duration()
+		timeout           = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("1h").Duration()
 
 		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -21,8 +21,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sigs.k8s.io/controller-runtime/pkg/config"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/config"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
@@ -55,7 +56,7 @@ func main() {
 		leaderElection    = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
 		createGracePeriod = app.Flag("create-grace-period", "Grace period for creation of IONOS Cloud resources.").Default("1m").Duration()
 		maxReconcileRate  = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("1").Int()
-		timeout           = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("30m").Duration()
+		timeout           = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("4h").Duration()
 
 		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()

--- a/internal/controller/serverset/create_before_destroy.go
+++ b/internal/controller/serverset/create_before_destroy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type updater interface {
@@ -16,7 +15,6 @@ type createBeforeDestroy struct {
 	serverController       kubeServerControlManager
 	nicController          kubeNicControlManager
 	firewallRuleController kubeFirewallRuleControlManager
-	kube client.Client
 }
 
 func newCreateBeforeDestroy(

--- a/internal/controller/serverset/server_controller.go
+++ b/internal/controller/serverset/server_controller.go
@@ -3,6 +3,8 @@ package serverset
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
@@ -10,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/kube"

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -764,7 +764,8 @@ func (e *external) ensureServerAndNicByIndex(ctx context.Context, cr *v1alpha1.S
 		if serverID == "" {
 			_ = e.serverController.Delete(ctx, resSrv.Items[0].Name, cr.Namespace)
 			return fmt.Errorf(
-				"server creation went wrong, serverID is empty for replica %d, attempting to recreate", replicaIndex,
+				"server creation went wrong, serverID is empty for replica %d of serverset %s, attempting to recreate",
+				replicaIndex, cr.Name,
 			)
 		}
 

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -758,20 +758,22 @@ func (e *external) ensureServerAndNicByIndex(ctx context.Context, cr *v1alpha1.S
 		}
 	}
 
-	serverID := resSrv.Items[0].Status.AtProvider.ServerID
-	if serverID == "" {
-		_ = e.serverController.Delete(ctx, resSrv.Items[0].Name, cr.Namespace)
-		return fmt.Errorf(
-			"server creation went wrong, serverID is empty for replica %d, attempting to recreate", replicaIndex,
-		)
-	}
+	if len(resSrv.Items) > 0 {
+		serverID := resSrv.Items[0].Status.AtProvider.ServerID
+		if serverID == "" {
+			_ = e.serverController.Delete(ctx, resSrv.Items[0].Name, cr.Namespace)
+			return fmt.Errorf(
+				"server creation went wrong, serverID is empty for replica %d, attempting to recreate", replicaIndex,
+			)
+		}
 
-	if err := e.nicController.EnsureNICs(ctx, cr, replicaIndex, version, serverID); err != nil {
-		return err
-	}
+		if err := e.nicController.EnsureNICs(ctx, cr, replicaIndex, version, serverID); err != nil {
+			return err
+		}
 
-	if err := e.firewallRuleController.EnsureFirewallRules(ctx, cr, replicaIndex, version, serverID); err != nil {
-		return err
+		if err := e.firewallRuleController.EnsureFirewallRules(ctx, cr, replicaIndex, version, serverID); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -663,9 +663,10 @@ func GetNICsOfSSet(ctx context.Context, kube client.Client, name string) ([]v1al
 
 // ListResFromSSetWithIndex - lists resources from a server set with a specific index label
 func ListResFromSSetWithIndex(ctx context.Context, kube client.Client, serversetName, resType string, index int, list client.ObjectList) error {
-	return kube.List(ctx, list, client.MatchingLabels{
+	label := client.MatchingLabels{
 		fmt.Sprintf(indexLabel, serversetName, resType): strconv.Itoa(index),
-	})
+	}
+	return kube.List(ctx, list, label)
 }
 
 // listResFromSSetWithIndexAndVersion - lists resources from a server set with a specific index and version label

--- a/internal/controller/serverset/serverset_test.go
+++ b/internal/controller/serverset/serverset_test.go
@@ -1681,7 +1681,7 @@ func fakeServerCtrlEnsureMethodReturnsErr() kubeServerControlManager {
 func fakeNicCtrlEnsureNICsMethodBasic() kubeNicControlManager {
 	nicCtrl := new(kubeNicControlManagerFake)
 	nicCtrl.
-		On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).
 		Times(0)
 	return nicCtrl
@@ -1691,7 +1691,7 @@ func fakeNicCtrlEnsureNICsMethod(timesCalled int) kubeNicControlManager {
 	nicCtrl := new(kubeNicControlManagerFake)
 	if timesCalled > 0 {
 		nicCtrl.
-			On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
 			Times(noReplicas)
 	}
@@ -1701,7 +1701,7 @@ func fakeNicCtrlEnsureNICsMethod(timesCalled int) kubeNicControlManager {
 func fakeNicCtrlEnsureNICsMethodReturnsErr() kubeNicControlManager {
 	nicCtrl := new(kubeNicControlManagerFake)
 	nicCtrl.
-		On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(errAnErrorWasReceived).
 		Times(1)
 
@@ -1711,7 +1711,8 @@ func fakeNicCtrlEnsureNICsMethodReturnsErr() kubeNicControlManager {
 func fakeNicCtrl() kubeNicControlManager {
 	nicCtrl := new(kubeNicControlManagerFake)
 	nicCtrl.
-		On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).
+		On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).
 		On(deleteMethod, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	return nicCtrl
 }
@@ -1719,7 +1720,7 @@ func fakeNicCtrl() kubeNicControlManager {
 func fakeFirewallRuleCtrlEnsureMethodBasic() kubeFirewallRuleControlManager {
 	firewallRuleCtrl := new(kubeFirewallRuleControlManagerFake)
 	firewallRuleCtrl.
-		On(ensureFirewallRulesMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		On(ensureFirewallRulesMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil).
 		Times(0)
 	return firewallRuleCtrl
@@ -1729,7 +1730,7 @@ func fakeFirewallRuleCtrlEnsureMethod(timesCalled int) kubeFirewallRuleControlMa
 	firewallRuleCtrl := new(kubeFirewallRuleControlManagerFake)
 	if timesCalled > 0 {
 		firewallRuleCtrl.
-			On(ensureFirewallRulesMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			On(ensureFirewallRulesMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
 			Times(timesCalled)
 	}
@@ -1739,7 +1740,8 @@ func fakeFirewallRuleCtrlEnsureMethod(timesCalled int) kubeFirewallRuleControlMa
 func fakeFirewallRuleCtrl() kubeFirewallRuleControlManager {
 	firewallRuleCtrl := new(kubeFirewallRuleControlManagerFake)
 	firewallRuleCtrl.
-		On(ensureFirewallRulesMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).
+		On(ensureFirewallRulesMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).
 		On(deleteMethod, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	return firewallRuleCtrl
 }
@@ -1823,8 +1825,10 @@ func (f *kubeServerCallTracker) Delete(ctx context.Context, name, ns string) err
 	return nil
 }
 
-func (f *kubeNicControlManagerFake) EnsureNICs(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int) error {
-	args := f.Called(ctx, cr, replicaIndex, version)
+func (f *kubeNicControlManagerFake) EnsureNICs(
+	ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int, serverID string,
+) error {
+	args := f.Called(ctx, cr, replicaIndex, version, serverID)
 	return args.Error(0)
 }
 
@@ -1833,8 +1837,10 @@ func (f *kubeNicControlManagerFake) Delete(ctx context.Context, name, ns string)
 	return args.Error(0)
 }
 
-func (f *kubeNicCallTracker) EnsureNICs(ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int) error {
-	f.lastMethodCall[ensureNICsMethod] = []any{ctx, cr, replicaIndex, version}
+func (f *kubeNicCallTracker) EnsureNICs(
+	ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int, stringID string,
+) error {
+	f.lastMethodCall[ensureNICsMethod] = []any{ctx, cr, replicaIndex, version, serverID}
 	return nil
 }
 
@@ -1844,9 +1850,9 @@ func (f *kubeNicCallTracker) Delete(ctx context.Context, name, ns string) error 
 }
 
 func (f *kubeFirewallRuleControlManagerFake) EnsureFirewallRules(
-	ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int,
+	ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int, serverID string,
 ) error {
-	args := f.Called(ctx, cr, replicaIndex, version)
+	args := f.Called(ctx, cr, replicaIndex, version, serverID)
 	return args.Error(0)
 }
 
@@ -1856,9 +1862,9 @@ func (f *kubeFirewallRuleControlManagerFake) Delete(ctx context.Context, name, n
 }
 
 func (f *kubeFirewallRuleCallTracker) EnsureFirewallRules(
-	ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int,
+	ctx context.Context, cr *v1alpha1.ServerSet, replicaIndex, version int, serverID string,
 ) error {
-	f.lastMethodCall[ensureFirewallRulesMethod] = []any{ctx, cr, replicaIndex, version}
+	f.lastMethodCall[ensureFirewallRulesMethod] = []any{ctx, cr, replicaIndex, version, serverID}
 	return nil
 }
 

--- a/internal/controller/serverset/serverset_test.go
+++ b/internal/controller/serverset/serverset_test.go
@@ -793,12 +793,13 @@ func Test_serverSetController_Create(t *testing.T) {
 		{
 			name: "server set successfully created",
 			fields: fields{
-				log:                    logging.NewNopLogger(),
-				kube:                   fakeKubeClientObjs(),
-				bootVolumeController:   fakeBootVolumeCtrlGetEnsure(),
-				serverController:       fakeServerCtrlGetEnsure(),
-				nicController:          fakeNicCtrlEnsureNICsMethod(noReplicas),
-				firewallRuleController: fakeFirewallRuleCtrlEnsureMethod(noReplicas),
+				log:                  logging.NewNopLogger(),
+				kube:                 fakeKubeClientObjs(),
+				bootVolumeController: fakeBootVolumeCtrlGetEnsure(),
+				serverController:     fakeServerCtrlGetEnsure(),
+				// will not get called due to listresources by lavel where it doesn't find a server
+				nicController:          fakeNicCtrlEnsureNICsMethod(0),
+				firewallRuleController: fakeFirewallRuleCtrlEnsureMethod(0),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -835,8 +836,8 @@ func Test_serverSetController_Create(t *testing.T) {
 				kube:                   fakeKubeClientObjs(),
 				bootVolumeController:   fakeBootVolumeCtrlEnsureMethodReturnsErr(),
 				serverController:       fakeServerCtrlEnsureMethod(1),
-				nicController:          fakeNicCtrlEnsureNICsMethodBasic(),
-				firewallRuleController: fakeFirewallRuleCtrlEnsureMethodBasic(),
+				nicController:          fakeNicCtrlEnsureNICsMethod(0),
+				firewallRuleController: fakeFirewallRuleCtrlEnsureMethod(0),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -885,9 +886,9 @@ func Test_serverSetController_Create(t *testing.T) {
 			name: "error when ensuring NICs",
 			fields: fields{
 				log:                    logging.NewNopLogger(),
-				kube:                   fakeKubeClientObjs(),
+				kube:                   fakeKubeClientOneServer(),
 				bootVolumeController:   new(kubeBootVolumeControlManagerFake),
-				serverController:       fakeServerCtrlEnsureMethod(1),
+				serverController:       new(kubeServerControlManagerFake),
 				nicController:          fakeNicCtrlEnsureNICsMethodReturnsErr(),
 				firewallRuleController: fakeFirewallRuleCtrlEnsureMethod(0),
 			},
@@ -1094,12 +1095,12 @@ func Test_serverSetController_BootVolumeUpdate(t *testing.T) {
 		{
 			name: "updated using default strategy (image changed)",
 			fields: fields{
-				kube:                    fakeKubeClientUpdateMethodForBootVolume(),
-				bootVolumeController:    fakeBootVolumeCtrl(),
-				serverController:        fakeServerCtrl(),
-				nicController:           fakeNicCtrl(),
-				firewallRuleController : fakeFirewallRuleCtrl(),
-				log:                     logging.NewNopLogger(),
+				kube:                   fakeKubeClientUpdateMethodForBootVolume(),
+				bootVolumeController:   fakeBootVolumeCtrl(),
+				serverController:       fakeServerCtrl(),
+				nicController:          fakeNicCtrl(),
+				firewallRuleController: fakeFirewallRuleCtrl(),
+				log:                    logging.NewNopLogger(),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -1124,12 +1125,12 @@ func Test_serverSetController_BootVolumeUpdate(t *testing.T) {
 		{
 			name: "updated using default strategy (type changed)",
 			fields: fields{
-				kube:                    fakeKubeClientUpdateMethodForBootVolume(),
-				bootVolumeController:    fakeBootVolumeCtrl(),
-				serverController:        fakeServerCtrl(),
-				nicController:           fakeNicCtrl(),
-				firewallRuleController : fakeFirewallRuleCtrl(),
-				log:                     logging.NewNopLogger(),
+				kube:                   fakeKubeClientUpdateMethodForBootVolume(),
+				bootVolumeController:   fakeBootVolumeCtrl(),
+				serverController:       fakeServerCtrl(),
+				nicController:          fakeNicCtrl(),
+				firewallRuleController: fakeFirewallRuleCtrl(),
+				log:                    logging.NewNopLogger(),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -1154,12 +1155,12 @@ func Test_serverSetController_BootVolumeUpdate(t *testing.T) {
 		{
 			name: "updated using createAllBeforeDestroy strategy (type changed)",
 			fields: fields{
-				kube:                    fakeKubeClientUpdateMethodForBootVolume(),
-				bootVolumeController:    fakeBootVolumeCtrl(),
-				nicController:           fakeNicCtrl(),
-				serverController:        fakeServerCtrl(),
-				firewallRuleController : fakeFirewallRuleCtrl(),
-				log:                     logging.NewNopLogger(),
+				kube:                   fakeKubeClientUpdateMethodForBootVolume(),
+				bootVolumeController:   fakeBootVolumeCtrl(),
+				nicController:          fakeNicCtrl(),
+				serverController:       fakeServerCtrl(),
+				firewallRuleController: fakeFirewallRuleCtrl(),
+				log:                    logging.NewNopLogger(),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -1188,12 +1189,12 @@ func Test_serverSetController_BootVolumeUpdate(t *testing.T) {
 		{
 			name: "updated (size changed)",
 			fields: fields{
-				kube:                    fakeKubeClientUpdateMethod(&v1alpha1.Volume{}),
-				bootVolumeController:    fakeBootVolumeCtrl(),
-				nicController:           fakeNicCtrl(),
-				serverController:        fakeServerCtrl(),
-				firewallRuleController : fakeFirewallRuleCtrl(),
-				log:                     logging.NewNopLogger(),
+				kube:                   fakeKubeClientUpdateMethod(&v1alpha1.Volume{}),
+				bootVolumeController:   fakeBootVolumeCtrl(),
+				nicController:          fakeNicCtrl(),
+				serverController:       fakeServerCtrl(),
+				firewallRuleController: fakeFirewallRuleCtrl(),
+				log:                    logging.NewNopLogger(),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -1214,12 +1215,12 @@ func Test_serverSetController_BootVolumeUpdate(t *testing.T) {
 		{
 			name: "failed to update (size changed)",
 			fields: fields{
-				kube:                    fakeKubeClientUpdateMethodReturnsError(),
-				bootVolumeController:    fakeBootVolumeCtrl(),
-				nicController:           fakeNicCtrl(),
-				serverController:        fakeServerCtrl(),
-				firewallRuleController : fakeFirewallRuleCtrl(),
-				log:                     logging.NewNopLogger(),
+				kube:                   fakeKubeClientUpdateMethodReturnsError(),
+				bootVolumeController:   fakeBootVolumeCtrl(),
+				nicController:          fakeNicCtrl(),
+				serverController:       fakeServerCtrl(),
+				firewallRuleController: fakeFirewallRuleCtrl(),
+				log:                    logging.NewNopLogger(),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -1238,12 +1239,12 @@ func Test_serverSetController_BootVolumeUpdate(t *testing.T) {
 		{
 			name: "failed to update using default strategy (type changed)",
 			fields: fields{
-				kube:                    fakeKubeClientUpdateMethodForBootVolume(),
-				bootVolumeController:    fakeBootVolumeCtrlGetEnsureMethodReturnsErr(),
-				nicController:           fakeNicCtrl(),
-				serverController:        fakeServerCtrl(),
-				firewallRuleController : fakeFirewallRuleCtrl(),
-				log:                     logging.NewNopLogger(),
+				kube:                   fakeKubeClientUpdateMethodForBootVolume(),
+				bootVolumeController:   fakeBootVolumeCtrlGetEnsureMethodReturnsErr(),
+				nicController:          fakeNicCtrl(),
+				serverController:       fakeServerCtrl(),
+				firewallRuleController: fakeFirewallRuleCtrl(),
+				log:                    logging.NewNopLogger(),
 			},
 			args: args{
 				ctx: context.Background(),
@@ -1264,12 +1265,12 @@ func Test_serverSetController_BootVolumeUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &external{
-				kube:                    tt.fields.kube,
-				bootVolumeController:    tt.fields.bootVolumeController,
-				nicController:           tt.fields.nicController,
-				serverController:        tt.fields.serverController,
-				firewallRuleController : tt.fields.firewallRuleController,
-				log:                     tt.fields.log,
+				kube:                   tt.fields.kube,
+				bootVolumeController:   tt.fields.bootVolumeController,
+				nicController:          tt.fields.nicController,
+				serverController:       tt.fields.serverController,
+				firewallRuleController: tt.fields.firewallRuleController,
+				log:                    tt.fields.log,
 			}
 
 			got, err := e.Update(tt.args.ctx, tt.args.cr)
@@ -1518,6 +1519,15 @@ func fakeKubeClientUpdateMethodReturnsError() client.Client {
 	return &kubeClient
 }
 
+func fakeKubeClientOneServer() client.Client {
+	kubeClient := kubeClientFake{
+		Client: fakeKubeClientObjs(
+			createServer("server1"),
+		),
+	}
+	return &kubeClient
+}
+
 func fakeKubeClientUpdateMethod(expectedObj client.Object) client.Client {
 	kubeClient := kubeClientFake{
 		Client: fakeKubeClientObjs(
@@ -1601,6 +1611,16 @@ func (f *kubeClientFake) shouldReturnError(obj client.Object) bool {
 	default:
 		return false
 	}
+}
+
+func fakeBootVolumeCtrlEnsure() kubeBootVolumeControlManager {
+	bootVolumeCtrl := new(kubeBootVolumeControlManagerFake)
+	bootVolumeCtrl.
+		On(ensureMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).
+		On(getMethod, mock.Anything, mock.Anything, mock.Anything).Return(&v1alpha1.Volume{}, nil)
+
+	return bootVolumeCtrl
+
 }
 
 func fakeBootVolumeCtrlGetEnsure() kubeBootVolumeControlManager {
@@ -1693,7 +1713,7 @@ func fakeNicCtrlEnsureNICsMethod(timesCalled int) kubeNicControlManager {
 		nicCtrl.
 			On(ensureNICsMethod, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil).
-			Times(noReplicas)
+			Times(timesCalled)
 	}
 	return nicCtrl
 }
@@ -1890,7 +1910,8 @@ func createServer(name string) *v1alpha1.Server {
 		},
 		Status: v1alpha1.ServerStatus{
 			AtProvider: v1alpha1.ServerObservation{
-				State: ionoscloud.Available,
+				State:    ionoscloud.Available,
+				ServerID: "serverID",
 			},
 		},
 		Spec: v1alpha1.ServerSpec{


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Increased root ctx timeout from 30m to 1h.
Refactored sset ensure functions to implement an additional check for empty serverID after server creation.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
