### PR TITLE
docs: allow resource exclusion from docs generation

### DIFF
--- a/docs/api/compute-engine/s3key.md
+++ b/docs/api/compute-engine/s3key.md
@@ -76,6 +76,7 @@ In order to configure the IONOS Cloud Resource, the user can set the `spec.forPr
 
 * `active` (boolean)
 	* description: Whether the IONOS Object Storage is active / enabled or not. Can only be updated to false, by default the key will be created as active. Default value is true.
+	* default: true
 * `userID` (string)
 	* description: The UUID of the user owning the IONOS Object Storage Key.
 

--- a/docs/api/compute-engine/serverset.md
+++ b/docs/api/compute-engine/serverset.md
@@ -274,6 +274,186 @@ available CPU architectures can be retrieved from the datacenter resource.
 					* properties:
 						* `dhcp` (boolean)
 						* `dhcpv6` (boolean)
+						* `firewallActive` (boolean)
+						* `firewallRules` (array)
+							* properties:
+								* `icmpCode` (integer)
+									* description: Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. Value null allows all codes.
+									* format: int32
+									* minimum: 0.000000
+									* maximum: 254.000000
+								* `icmpType` (integer)
+									* description: Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen. Value null allows all types.
+									* format: int32
+									* minimum: 0.000000
+									* maximum: 254.000000
+								* `name` (string)
+									* description: The name of the  resource.
+								* `portRangeEnd` (integer)
+									* description: Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen.
+Leave portRangeStart and portRangeEnd null to allow all ports.
+									* format: int32
+									* minimum: 1.000000
+									* maximum: 65534.000000
+								* `portRangeStart` (integer)
+									* description: Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen.
+Leave portRangeStart and portRangeEnd value null to allow all ports.
+									* format: int32
+									* minimum: 1.000000
+									* maximum: 65534.000000
+								* `protocol` (string)
+									* description: The protocol for the rule. Property cannot be modified after it is created (disallowed in update requests).
+									* possible values: "TCP";"UDP";"ICMP";"ANY"
+								* `sourceIpConfig` (object)
+									* description: Only traffic originating from the respective IPv4 address is allowed.
+Value null allows traffic from any IP address.
+SourceIP can be set directly or via reference to an IP Block and index.
+									* properties:
+										* `ip` (string)
+											* description: Use IP or CIDR to set specific IP or CIDR to the resource. If both IP and IPBlockConfig are set,
+only `ip` field will be considered.
+											* pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$
+										* `ipBlockConfig` (object)
+											* description: Use IpBlockConfig to reference existing IPBlock, and to mention the index for the IP.
+Index starts from 0 and it must be provided.
+											* properties:
+												* `index` (integer)
+													* description: Index is referring to the IP index retrieved from the IPBlock.
+Index is starting from 0.
+												* `ipBlockId` (string)
+													* description: IPBlockID is the ID of the IPBlock on which the resource will be created.
+It needs to be provided via directly or via reference.
+													* format: uuid
+												* `ipBlockIdRef` (object)
+													* description: IPBlockIDRef references to a IPBlock to retrieve its ID.
+													* properties:
+														* `name` (string)
+															* description: Name of the referenced object.
+														* `policy` (object)
+															* description: Policies for referencing.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+													* required properties:
+														* `name`
+												* `ipBlockIdSelector` (object)
+													* description: IPBlockIDSelector selects reference to a IPBlock to retrieve its IPBlockID.
+													* properties:
+														* `matchControllerRef` (boolean)
+															* description: MatchControllerRef ensures an object with the same controller reference
+as the selecting object is selected.
+														* `matchLabels` (object)
+															* description: MatchLabels ensures an object with matching labels is selected.
+														* `policy` (object)
+															* description: Policies for selection.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+											* required properties:
+												* `index`
+								* `sourceMac` (string)
+									* description: Only traffic originating from the respective MAC address is allowed.
+Valid format: aa:bb:cc:dd:ee:ff. Value null allows traffic from any MAC address.
+									* pattern: ^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$
+								* `targetIpConfig` (object)
+									* description: If the target NIC has multiple IP addresses, only the traffic directed to the respective IP address of the NIC is allowed.
+Value null allows traffic to any target IP address.
+TargetIP can be set directly or via reference to an IP Block and index.
+									* properties:
+										* `ip` (string)
+											* description: Use IP or CIDR to set specific IP or CIDR to the resource. If both IP and IPBlockConfig are set,
+only `ip` field will be considered.
+											* pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$
+										* `ipBlockConfig` (object)
+											* description: Use IpBlockConfig to reference existing IPBlock, and to mention the index for the IP.
+Index starts from 0 and it must be provided.
+											* properties:
+												* `index` (integer)
+													* description: Index is referring to the IP index retrieved from the IPBlock.
+Index is starting from 0.
+												* `ipBlockId` (string)
+													* description: IPBlockID is the ID of the IPBlock on which the resource will be created.
+It needs to be provided via directly or via reference.
+													* format: uuid
+												* `ipBlockIdRef` (object)
+													* description: IPBlockIDRef references to a IPBlock to retrieve its ID.
+													* properties:
+														* `name` (string)
+															* description: Name of the referenced object.
+														* `policy` (object)
+															* description: Policies for referencing.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+													* required properties:
+														* `name`
+												* `ipBlockIdSelector` (object)
+													* description: IPBlockIDSelector selects reference to a IPBlock to retrieve its IPBlockID.
+													* properties:
+														* `matchControllerRef` (boolean)
+															* description: MatchControllerRef ensures an object with the same controller reference
+as the selecting object is selected.
+														* `matchLabels` (object)
+															* description: MatchLabels ensures an object with matching labels is selected.
+														* `policy` (object)
+															* description: Policies for selection.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+											* required properties:
+												* `index`
+								* `type` (string)
+									* description: The type of the firewall rule. If not specified, the default INGRESS value is used.
+									* possible values: "INGRESS";"EGRESS"
+							* required properties:
+								* `protocol`
+						* `firewallType` (string)
+							* description: The type of firewall rules that will be allowed on the NIC. If not specified, the default INGRESS value is used.
+							* possible values: "BIDIRECTIONAL";"EGRESS";"INGRESS"
 						* `lanReference` (string)
 							* description: The Referenced LAN must be created before the ServerSet is applied
 						* `name` (string)

--- a/docs/api/compute-engine/statefulserverset.md
+++ b/docs/api/compute-engine/statefulserverset.md
@@ -300,6 +300,186 @@ available CPU architectures can be retrieved from the datacenter resource.
 					* properties:
 						* `dhcp` (boolean)
 						* `dhcpv6` (boolean)
+						* `firewallActive` (boolean)
+						* `firewallRules` (array)
+							* properties:
+								* `icmpCode` (integer)
+									* description: Defines the allowed code (from 0 to 254) if protocol ICMP is chosen. Value null allows all codes.
+									* format: int32
+									* minimum: 0.000000
+									* maximum: 254.000000
+								* `icmpType` (integer)
+									* description: Defines the allowed type (from 0 to 254) if the protocol ICMP is chosen. Value null allows all types.
+									* format: int32
+									* minimum: 0.000000
+									* maximum: 254.000000
+								* `name` (string)
+									* description: The name of the  resource.
+								* `portRangeEnd` (integer)
+									* description: Defines the end range of the allowed port (from 1 to 65534) if the protocol TCP or UDP is chosen.
+Leave portRangeStart and portRangeEnd null to allow all ports.
+									* format: int32
+									* minimum: 1.000000
+									* maximum: 65534.000000
+								* `portRangeStart` (integer)
+									* description: Defines the start range of the allowed port (from 1 to 65534) if protocol TCP or UDP is chosen.
+Leave portRangeStart and portRangeEnd value null to allow all ports.
+									* format: int32
+									* minimum: 1.000000
+									* maximum: 65534.000000
+								* `protocol` (string)
+									* description: The protocol for the rule. Property cannot be modified after it is created (disallowed in update requests).
+									* possible values: "TCP";"UDP";"ICMP";"ANY"
+								* `sourceIpConfig` (object)
+									* description: Only traffic originating from the respective IPv4 address is allowed.
+Value null allows traffic from any IP address.
+SourceIP can be set directly or via reference to an IP Block and index.
+									* properties:
+										* `ip` (string)
+											* description: Use IP or CIDR to set specific IP or CIDR to the resource. If both IP and IPBlockConfig are set,
+only `ip` field will be considered.
+											* pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$
+										* `ipBlockConfig` (object)
+											* description: Use IpBlockConfig to reference existing IPBlock, and to mention the index for the IP.
+Index starts from 0 and it must be provided.
+											* properties:
+												* `index` (integer)
+													* description: Index is referring to the IP index retrieved from the IPBlock.
+Index is starting from 0.
+												* `ipBlockId` (string)
+													* description: IPBlockID is the ID of the IPBlock on which the resource will be created.
+It needs to be provided via directly or via reference.
+													* format: uuid
+												* `ipBlockIdRef` (object)
+													* description: IPBlockIDRef references to a IPBlock to retrieve its ID.
+													* properties:
+														* `name` (string)
+															* description: Name of the referenced object.
+														* `policy` (object)
+															* description: Policies for referencing.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+													* required properties:
+														* `name`
+												* `ipBlockIdSelector` (object)
+													* description: IPBlockIDSelector selects reference to a IPBlock to retrieve its IPBlockID.
+													* properties:
+														* `matchControllerRef` (boolean)
+															* description: MatchControllerRef ensures an object with the same controller reference
+as the selecting object is selected.
+														* `matchLabels` (object)
+															* description: MatchLabels ensures an object with matching labels is selected.
+														* `policy` (object)
+															* description: Policies for selection.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+											* required properties:
+												* `index`
+								* `sourceMac` (string)
+									* description: Only traffic originating from the respective MAC address is allowed.
+Valid format: aa:bb:cc:dd:ee:ff. Value null allows traffic from any MAC address.
+									* pattern: ^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$
+								* `targetIpConfig` (object)
+									* description: If the target NIC has multiple IP addresses, only the traffic directed to the respective IP address of the NIC is allowed.
+Value null allows traffic to any target IP address.
+TargetIP can be set directly or via reference to an IP Block and index.
+									* properties:
+										* `ip` (string)
+											* description: Use IP or CIDR to set specific IP or CIDR to the resource. If both IP and IPBlockConfig are set,
+only `ip` field will be considered.
+											* pattern: ^([0-9]{1,3}\.){3}[0-9]{1,3}(/([0-9]|[1-2][0-9]|3[0-2]))?$
+										* `ipBlockConfig` (object)
+											* description: Use IpBlockConfig to reference existing IPBlock, and to mention the index for the IP.
+Index starts from 0 and it must be provided.
+											* properties:
+												* `index` (integer)
+													* description: Index is referring to the IP index retrieved from the IPBlock.
+Index is starting from 0.
+												* `ipBlockId` (string)
+													* description: IPBlockID is the ID of the IPBlock on which the resource will be created.
+It needs to be provided via directly or via reference.
+													* format: uuid
+												* `ipBlockIdRef` (object)
+													* description: IPBlockIDRef references to a IPBlock to retrieve its ID.
+													* properties:
+														* `name` (string)
+															* description: Name of the referenced object.
+														* `policy` (object)
+															* description: Policies for referencing.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+													* required properties:
+														* `name`
+												* `ipBlockIdSelector` (object)
+													* description: IPBlockIDSelector selects reference to a IPBlock to retrieve its IPBlockID.
+													* properties:
+														* `matchControllerRef` (boolean)
+															* description: MatchControllerRef ensures an object with the same controller reference
+as the selecting object is selected.
+														* `matchLabels` (object)
+															* description: MatchLabels ensures an object with matching labels is selected.
+														* `policy` (object)
+															* description: Policies for selection.
+															* properties:
+																* `resolution` (string)
+																	* description: Resolution specifies whether resolution of this reference is required.
+The default is 'Required', which means the reconcile will fail if the
+reference cannot be resolved. 'Optional' means this reference will be
+a no-op if it cannot be resolved.
+																	* default: "Required"
+																	* possible values: "Required";"Optional"
+																* `resolve` (string)
+																	* description: Resolve specifies when this reference should be resolved. The default
+is 'IfNotPresent', which will attempt to resolve the reference only when
+the corresponding field is not present. Use 'Always' to resolve the
+reference on every reconcile.
+																	* possible values: "Always";"IfNotPresent"
+											* required properties:
+												* `index`
+								* `type` (string)
+									* description: The type of the firewall rule. If not specified, the default INGRESS value is used.
+									* possible values: "INGRESS";"EGRESS"
+							* required properties:
+								* `protocol`
+						* `firewallType` (string)
+							* description: The type of firewall rules that will be allowed on the NIC. If not specified, the default INGRESS value is used.
+							* possible values: "BIDIRECTIONAL";"EGRESS";"INGRESS"
 						* `lanReference` (string)
 							* description: The Referenced LAN must be created before the ServerSet is applied
 						* `name` (string)

--- a/docs/api/database-as-a-service/mongouser.md
+++ b/docs/api/database-as-a-service/mongouser.md
@@ -176,6 +176,9 @@ Password must have a minimum length o 10
 			* description: Database on which to set the role
 		* `role` (string)
 			* description: Role to set for the user
+	* required properties:
+		* `database`
+		* `role`
 
 ### Required Properties
 
@@ -183,6 +186,7 @@ The user needs to set the following properties in order to configure the IONOS C
 
 * `clusterConfig`
 * `credentials`
+* `userRoles`
 
 ## Resource Definition
 

--- a/docs/api/database-as-a-service/postgresdatabase.md
+++ b/docs/api/database-as-a-service/postgresdatabase.md
@@ -129,10 +129,7 @@ the corresponding field is not present. Use 'Always' to resolve the
 reference on every reconcile.
 							* possible values: "Always";"IfNotPresent"
 * `name` (string)
-	* description: The databasename of a given database.
-
-
-Database credentials - either set directly, or as secret/path/env
+	* description: The database name.
 * `owner` (object)
 	* description: The name of the role owning a given database.
 	* properties:

--- a/docs/api/database-as-a-service/postgresuser.md
+++ b/docs/api/database-as-a-service/postgresuser.md
@@ -131,7 +131,6 @@ reference on every reconcile.
 * `credentials` (object)
 	* description: The total number of instances in the cluster (one master and n-1 standbys).
 
-
 Database credentials - either set directly, or as secret/path/env
 	* properties:
 		* `env` (object)

--- a/docs/api/dataplatform/dataplatformcluster.md
+++ b/docs/api/dataplatform/dataplatformcluster.md
@@ -147,6 +147,7 @@ reference on every reconcile.
 The user needs to set the following properties in order to configure the IONOS Cloud Resource:
 
 * `datacenterConfig`
+* `name`
 * `version`
 
 ## Resource Definition

--- a/docs/api/dataplatform/dataplatformnodepool.md
+++ b/docs/api/dataplatform/dataplatformnodepool.md
@@ -225,6 +225,7 @@ Possible values HDD;SSD
 The user needs to set the following properties in order to configure the IONOS Cloud Resource:
 
 * `clusterConfig`
+* `name`
 * `nodeCount`
 
 ## Resource Definition


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
