### PR TITLE
fix: do not trigger update on node count when nodepool autoscaling happens

### DIFF
--- a/internal/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/clients/k8s/k8snodepool/nodepool.go
@@ -181,7 +181,7 @@ func GenerateUpdateK8sNodePoolInput(cr *v1alpha1.NodePool, publicIps []string) *
 			K8sVersion: &cr.Spec.ForProvider.K8sVersion,
 		},
 	}
-	if !utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.AutoScaling.MinNodeCount)) {
+	if !utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.AutoScaling)) {
 		instanceUpdateInput.Properties.SetAutoScaling(sdkgo.KubernetesAutoScaling{
 			MinNodeCount: &cr.Spec.ForProvider.AutoScaling.MinNodeCount,
 			MaxNodeCount: &cr.Spec.ForProvider.AutoScaling.MaxNodeCount,
@@ -284,7 +284,9 @@ func IsK8sNodePoolUpToDate(cr *v1alpha1.NodePool, nodepool sdkgo.KubernetesNodeP
 		return false
 	case nodepool.Properties.K8sVersion != nil && *nodepool.Properties.K8sVersion != cr.Spec.ForProvider.K8sVersion:
 		return false
-	case nodepool.Properties.NodeCount != nil && *nodepool.Properties.NodeCount != cr.Spec.ForProvider.NodeCount:
+	case nodepool.Properties.NodeCount != nil &&
+		*nodepool.Properties.NodeCount != cr.Spec.ForProvider.NodeCount &&
+		utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.AutoScaling)):
 		return false
 	case nodepool.Properties.PublicIps != nil && !utils.ContainsStringSlices(*nodepool.Properties.PublicIps, publicIPs):
 		return false


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

Fixes https://github.com/ionos-cloud/crossplane-provider-ionoscloud/issues/296

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
