### PR TITLE
fix: update pcislot even if it is not 0

### DIFF
--- a/internal/controller/compute/volume/volume.go
+++ b/internal/controller/compute/volume/volume.go
@@ -159,9 +159,7 @@ func LateStatusInitializer(in *v1alpha1.VolumeObservation, volume *sdkgo.Volume)
 	// Add options to the Spec, if they were updated by the API
 	if propertiesOk, ok := volume.GetPropertiesOk(); ok && propertiesOk != nil {
 		if PCISlotOk, ok := propertiesOk.GetPciSlotOk(); ok && PCISlotOk != nil {
-			if in.PCISlot == 0 {
-				in.PCISlot = *PCISlotOk
-			}
+			in.PCISlot = *PCISlotOk
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes
When there are provisioning errors the pcislot can change in some edge cases. We need to re-update the vnetid in those cases.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
