### PR TITLE
fix: delete crd sub-resources only on 422. do not delete ss, update it

### DIFF
--- a/internal/controller/compute/statefulserverset/fakes_test.go
+++ b/internal/controller/compute/statefulserverset/fakes_test.go
@@ -105,7 +105,7 @@ func (f *fakeKubeServerSetController) Ensure(ctx context.Context, cr *v1alpha1.S
 	return nil
 }
 
-func (f *fakeKubeServerSetController) Update(ctx context.Context, cr *v1alpha1.StatefulServerSet) (v1alpha1.ServerSet, error) {
+func (f *fakeKubeServerSetController) Update(ctx context.Context, cr *v1alpha1.StatefulServerSet, forceUpdate bool) (v1alpha1.ServerSet, error) {
 	f.methodCallCount[update]++
 	return v1alpha1.ServerSet{}, nil
 

--- a/internal/controller/compute/statefulserverset/serverset_controller.go
+++ b/internal/controller/compute/statefulserverset/serverset_controller.go
@@ -116,7 +116,7 @@ func (k *kubeServerSetController) Ensure(ctx context.Context, cr *v1alpha1.State
 		// in case the serverset has an error, try to update it so it can update the sub-resources
 		_, err := k.Update(ctx, cr, true)
 		if err != nil {
-			k.log.Info("ServerSet failed to update", "name", SSetName)
+			k.log.Info("ServerSet failed to update", "name", SSetName, "error", err)
 		}
 		return kube.ErrExternalCreateFailed
 	}

--- a/internal/controller/compute/statefulserverset/serverset_controller.go
+++ b/internal/controller/compute/statefulserverset/serverset_controller.go
@@ -4,23 +4,22 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
-
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/kube"
 )
 
 type kubeSSetControlManager interface {
 	Create(ctx context.Context, cr *v1alpha1.StatefulServerSet) (*v1alpha1.ServerSet, error)
 	Ensure(ctx context.Context, cr *v1alpha1.StatefulServerSet) error
-	Update(ctx context.Context, cr *v1alpha1.StatefulServerSet) (v1alpha1.ServerSet, error)
+	Update(ctx context.Context, cr *v1alpha1.StatefulServerSet, forceUpdate bool) (v1alpha1.ServerSet, error)
 	Get(ctx context.Context, ssetName, ns string) (*v1alpha1.ServerSet, error)
 	Delete(ctx context.Context, name, namespace string) error
 }
@@ -47,23 +46,25 @@ func (k *kubeServerSetController) Create(ctx context.Context, cr *v1alpha1.State
 }
 
 // Update updates a server set CR
-func (k *kubeServerSetController) Update(ctx context.Context, cr *v1alpha1.StatefulServerSet) (v1alpha1.ServerSet, error) {
+func (k *kubeServerSetController) Update(ctx context.Context, cr *v1alpha1.StatefulServerSet, forceUpdate bool) (v1alpha1.ServerSet, error) {
 	name := getSSetName(cr)
 	updateObj, err := k.Get(ctx, name, cr.Namespace)
 	if err != nil {
 		return v1alpha1.ServerSet{}, err
 	}
 
-	areResUpToDate, _, err := areSSetResourcesReady(ctx, k.kube, cr)
-	if err != nil {
-		return v1alpha1.ServerSet{}, err
-	}
-	if areResUpToDate {
-		k.log.Info("ServerSet resources are up to date", "name", name)
-		return v1alpha1.ServerSet{}, nil
+	if !forceUpdate {
+		areResUpToDate, _, err := areSSetResourcesReady(ctx, k.kube, cr)
+		if err != nil {
+			return v1alpha1.ServerSet{}, err
+		}
+		if areResUpToDate {
+			k.log.Info("ServerSet resources are up to date", "name", name)
+			return v1alpha1.ServerSet{}, nil
+		}
 	}
 
-	k.log.Info("Updating ServerSet", "name", name)
+	k.log.Info("Updating ServerSet", "name", name, "forceUpdate", forceUpdate)
 	updateObj.Spec.ForProvider.Replicas = cr.Spec.ForProvider.Replicas
 	updateObj.Spec.ForProvider.Template = cr.Spec.ForProvider.Template
 	updateObj.Spec.ForProvider.BootVolumeTemplate = cr.Spec.ForProvider.BootVolumeTemplate
@@ -112,6 +113,11 @@ func (k *kubeServerSetController) Ensure(ctx context.Context, cr *v1alpha1.State
 	kubeSSet := &v1alpha1.ServerSet{}
 	err := k.kube.Get(ctx, types.NamespacedName{Name: SSetName, Namespace: cr.Namespace}, kubeSSet)
 	if kubeSSet != nil && !kube.IsSuccessfullyCreated(kubeSSet) {
+		// in case the serverset has an error, try to update it so it can update the sub-resources
+		_, err := k.Update(ctx, cr, true)
+		if err != nil {
+			k.log.Info("ServerSet failed to update", "name", SSetName)
+		}
 		return kube.ErrExternalCreateFailed
 	}
 	switch {
@@ -123,8 +129,6 @@ func (k *kubeServerSetController) Ensure(ctx context.Context, cr *v1alpha1.State
 
 		k.log.Info("Waiting for ServerSet to be available", "name", SSetName)
 		if err = kube.WaitForResource(ctx, kube.ServerSetReadyTimeout, k.isAvailable, SSetName, cr.Namespace); err != nil {
-			k.log.Info("ServerSet failed to become available, deleting it", "name", SSetName)
-			_ = k.Delete(ctx, SSetName, cr.Namespace)
 			return err
 		}
 	case err != nil:

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -275,7 +275,7 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) (managed.Ext
 			return managed.ExternalUpdate{}, err
 		}
 	}
-	_, err := e.SSetController.Update(ctx, cr)
+	_, err := e.SSetController.Update(ctx, cr, false)
 	if err != nil {
 		return managed.ExternalUpdate{}, fmt.Errorf("while updating ServerSet CR %w", err)
 	}

--- a/internal/controller/serverset/bootvolume_controller.go
+++ b/internal/controller/serverset/bootvolume_controller.go
@@ -8,7 +8,6 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/ccpatch"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/ccpatch/substitution"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/kube"
@@ -59,8 +59,10 @@ func (k *kubeBootVolumeController) Create(ctx context.Context, cr *v1alpha1.Serv
 
 	k.log.Info("Waiting for BootVolume to become available", "name", name, "serverset", cr.Name)
 	if err := kube.WaitForResource(ctx, kube.ResourceReadyTimeout, k.isAvailable, name, cr.Namespace); err != nil {
-		k.log.Info("BootVolume failed to become available, deleting it", "name", name, "serverset", cr.Name)
-		_ = k.Delete(ctx, createVolume.Name, cr.Namespace)
+		if strings.Contains(err.Error(), utils.Error422) {
+			k.log.Info("BootVolume failed to become available, deleting it", "name", name, "serverset", cr.Name)
+			_ = k.Delete(ctx, createVolume.Name, cr.Namespace)
+		}
 		return v1alpha1.Volume{}, fmt.Errorf("while waiting for BootVolume %s to be populated %w ", createVolume.Name, err)
 	}
 	// get the volume again before returning to have the id populated

--- a/internal/controller/serverset/firewallrule_controller.go
+++ b/internal/controller/serverset/firewallrule_controller.go
@@ -7,13 +7,14 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/kube"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/kube"
 )
 
 type kubeFirewallRuleControlManager interface {
@@ -63,8 +64,10 @@ func (k *kubeFirewallRuleController) Create(
 	if err := kube.WaitForResource(
 		ctx, kube.ResourceReadyTimeout, k.isAvailable, toBeCreatedFirewallRule.Name, cr.Namespace,
 	); err != nil {
-		k.log.Info("Firewall Rule failed to become available, deleting it", "name", toBeCreatedFirewallRule.Name, "serverset", cr.Name)
-		_ = k.Delete(ctx, toBeCreatedFirewallRule.Name, cr.Namespace)
+		if strings.Contains(err.Error(), utils.Error422) {
+			k.log.Info("Firewall Rule failed to become available, deleting it", "name", toBeCreatedFirewallRule.Name, "serverset", cr.Name)
+			_ = k.Delete(ctx, toBeCreatedFirewallRule.Name, cr.Namespace)
+		}
 		return v1alpha1.FirewallRule{}, fmt.Errorf(
 			"while waiting for Firewall Rule name %s to be populated for serverset %s %w", toBeCreatedFirewallRule.Name,
 			cr.Name, err,

--- a/internal/controller/serverset/server_controller.go
+++ b/internal/controller/serverset/server_controller.go
@@ -7,7 +7,6 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
-	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/compute/v1alpha1"
+	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/utils"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/pkg/kube"
 )
 
@@ -46,10 +46,13 @@ func (k *kubeServerController) Create(ctx context.Context, cr *v1alpha1.ServerSe
 
 	k.log.Info("Waiting for Server to become available", "name", createServer.Name, "serverset", cr.Name)
 	if err := kube.WaitForResource(ctx, kube.ResourceReadyTimeout, k.isAvailable, createServer.Name, cr.Namespace); err != nil {
-		k.log.Info("Server failed to become available, deleting it", "name", createServer.Name, "serverset", cr.Name)
-		_ = k.Delete(ctx, createServer.Name, cr.Namespace)
+		if strings.Contains(err.Error(), utils.Error422) {
+			k.log.Info("Server failed to become available, deleting it", "name", createServer.Name, "serverset", cr.Name, "err", err)
+			_ = k.Delete(ctx, createServer.Name, cr.Namespace)
+		}
 		return v1alpha1.Server{}, fmt.Errorf("while waiting for Server to be populated in serverset %s %w ", cr.Name, err)
 	}
+
 	createdServer, err := k.Get(ctx, createServer.Name, cr.Namespace)
 	if err != nil {
 		return v1alpha1.Server{}, fmt.Errorf("while getting created Server for serverset %s %w", cr.Name, err)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -11,6 +11,9 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Error422 is the error code for unprocessable entity
+const Error422 = "422 Unprocessable Entity"
+
 // DepthQueryParam is used in GET requests in Cloud API
 const DepthQueryParam = int32(1)
 

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -38,5 +38,24 @@ func WaitForResource(ctx context.Context, timeoutInMinutes time.Duration, fn IsR
 
 // IsSuccessfullyCreated checks if the object was successfully created
 func IsSuccessfullyCreated(obj resource.Managed) bool {
-	return obj.GetAnnotations()[meta.AnnotationKeyExternalCreateFailed] == ""
+	successAnnotation := obj.GetAnnotations()[meta.AnnotationKeyExternalCreateSucceeded]
+	failedAnnotation := obj.GetAnnotations()[meta.AnnotationKeyExternalCreateFailed]
+	if failedAnnotation == "" {
+		return true
+	}
+	if successAnnotation == "" {
+		return false
+	}
+	successTimestamp, err := time.Parse(time.RFC3339, successAnnotation)
+	if err != nil {
+		return false
+	}
+	failedTimestamp, err := time.Parse(time.RFC3339, failedAnnotation)
+	if err != nil {
+		return false
+	}
+	if successTimestamp.After(failedTimestamp) {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
