### PR TITLE
test: new version of crossplane provider for image library project

### DIFF
--- a/apis/compute/v1alpha1/statefulserverset_types.go
+++ b/apis/compute/v1alpha1/statefulserverset_types.go
@@ -108,11 +108,12 @@ type StatefulServerSetParameters struct {
 	// on which the server will be created.
 	//
 	// +kubebuilder:validation:Required
-	DatacenterCfg      DatacenterConfig          `json:"datacenterConfig"`
-	Template           ServerSetTemplate         `json:"template"`
-	BootVolumeTemplate BootVolumeTemplate        `json:"bootVolumeTemplate"`
-	Lans               []StatefulServerSetLan    `json:"lans"`
-	Volumes            []StatefulServerSetVolume `json:"volumes"`
+	DatacenterCfg      DatacenterConfig       `json:"datacenterConfig"`
+	Template           ServerSetTemplate      `json:"template"`
+	BootVolumeTemplate BootVolumeTemplate     `json:"bootVolumeTemplate"`
+	Lans               []StatefulServerSetLan `json:"lans"`
+	// +kubebuilder:validation:Optional
+	Volumes []StatefulServerSetVolume `json:"volumes"`
 	// IdentityConfigMap is the configMap from which the identity of the ACTIVE server in the ServerSet is read. The configMap
 	// should be created separately. The stateful serverset only reads the status from it. If it does not find it, it sets
 	// the first server as the ACTIVE.

--- a/internal/controller/compute/statefulserverset/datavolume_controller.go
+++ b/internal/controller/compute/statefulserverset/datavolume_controller.go
@@ -156,11 +156,12 @@ func fromSSSetToVolume(cr *v1alpha1.StatefulServerSet, name string, replicaIndex
 				DeletionPolicy:          cr.GetDeletionPolicy(),
 			},
 			ForProvider: v1alpha1.VolumeParameters{
-				DatacenterCfg:    cr.Spec.ForProvider.DatacenterCfg,
-				Name:             generateNameFrom(cr.Spec.ForProvider.Volumes[volumeIndex].Metadata.Name, replicaIndex, volumeIndex),
-				AvailabilityZone: serverset.GetZoneFromIndex(replicaIndex),
-				Size:             cr.Spec.ForProvider.Volumes[volumeIndex].Spec.Size,
-				Type:             cr.Spec.ForProvider.Volumes[volumeIndex].Spec.Type,
+				DatacenterCfg:     cr.Spec.ForProvider.DatacenterCfg,
+				Name:              generateNameFrom(cr.Spec.ForProvider.Volumes[volumeIndex].Metadata.Name, replicaIndex, volumeIndex),
+				AvailabilityZone:  serverset.GetZoneFromIndex(replicaIndex),
+				Size:              cr.Spec.ForProvider.Volumes[volumeIndex].Spec.Size,
+				Type:              cr.Spec.ForProvider.Volumes[volumeIndex].Spec.Type,
+				DiscVirtioHotPlug: true,
 			},
 		}}
 	if cr.Spec.ForProvider.Volumes[volumeIndex].Spec.Image != "" {

--- a/internal/controller/volumeselector/volumeselector.go
+++ b/internal/controller/volumeselector/volumeselector.go
@@ -265,10 +265,10 @@ func (c *externalVolumeselector) attachVolume(ctx context.Context, datacenterID,
 }
 
 func (c *externalVolumeselector) areVolumesAndServersReady(volumeList v1alpha1.VolumeList, serverList v1alpha1.ServerList) bool {
-	if len(volumeList.Items) == 0 {
-		c.log.Info("volumeselector no Volumes found")
-		return false
-	}
+	//if len(volumeList.Items) == 0 {
+	//	c.log.Info("volumeselector no Volumes found")
+	//	return false
+	//}
 	if len(serverList.Items) == 0 {
 		c.log.Info("volumeselector no Servers found")
 		return false

--- a/package/crds/compute.ionoscloud.crossplane.io_statefulserversets.yaml
+++ b/package/crds/compute.ionoscloud.crossplane.io_statefulserversets.yaml
@@ -910,7 +910,6 @@ spec:
                 - lans
                 - replicas
                 - template
-                - volumes
                 type: object
               managementPolicies:
                 default:


### PR DESCRIPTION
This PR is created for testing purpose for Image Library MVP product.

In short, we need to make volume in CRDs optional for our specific usecase.

link to diff: https://github.com/ionos-cloud/crossplane-provider-ionoscloud/compare/v1.1.16...v0.1.2-hotplug-test
