### PR TITLE
feat: make data volumes optional, required only if set and can only be added

### DIFF
--- a/apis/compute/v1alpha1/statefulserverset_types.go
+++ b/apis/compute/v1alpha1/statefulserverset_types.go
@@ -96,6 +96,7 @@ type StatefulServerSetVolume struct {
 }
 
 // StatefulServerSetParameters are the configurable fields of a StatefulServerSet.
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.volumes) || has(self.volumes)", message="Data volumes are required once set"
 type StatefulServerSetParameters struct {
 	// The number of servers that will be created. Cannot be decreased once set, only increased. Has a minimum of 1.
 	//
@@ -108,11 +109,13 @@ type StatefulServerSetParameters struct {
 	// on which the server will be created.
 	//
 	// +kubebuilder:validation:Required
-	DatacenterCfg      DatacenterConfig          `json:"datacenterConfig"`
-	Template           ServerSetTemplate         `json:"template"`
-	BootVolumeTemplate BootVolumeTemplate        `json:"bootVolumeTemplate"`
-	Lans               []StatefulServerSetLan    `json:"lans"`
-	Volumes            []StatefulServerSetVolume `json:"volumes"`
+	DatacenterCfg      DatacenterConfig       `json:"datacenterConfig"`
+	Template           ServerSetTemplate      `json:"template"`
+	BootVolumeTemplate BootVolumeTemplate     `json:"bootVolumeTemplate"`
+	Lans               []StatefulServerSetLan `json:"lans"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:XValidation:rule="self.size() >= oldSelf.size()", message="Number of data volumes can only be increased"
+	Volumes []StatefulServerSetVolume `json:"volumes"`
 	// IdentityConfigMap is the configMap from which the identity of the ACTIVE server in the ServerSet is read. The configMap
 	// should be created separately. The stateful serverset only reads the status from it. If it does not find it, it sets
 	// the first server as the ACTIVE.

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -199,7 +199,7 @@ func (e *external) isServerSetUpToDate(ctx context.Context, cr *v1alpha1.Statefu
 }
 
 func (e *external) isVolumeSelectorUpToDate(ctx context.Context, cr *v1alpha1.StatefulServerSet) (creationVSUpToDate bool, err error) {
-	if cr.Spec.ForProvider.Volumes == nil || len(cr.Spec.ForProvider.Volumes) == 0 {
+	if len(cr.Spec.ForProvider.Volumes) == 0 {
 		e.log.Info("Skipping VolumeSelector observation as no volumes are defined in the StatefulServerSet", "ssset", cr.Name)
 		return true, nil
 	}

--- a/internal/controller/compute/statefulserverset/statefulserverset.go
+++ b/internal/controller/compute/statefulserverset/statefulserverset.go
@@ -199,6 +199,11 @@ func (e *external) isServerSetUpToDate(ctx context.Context, cr *v1alpha1.Statefu
 }
 
 func (e *external) isVolumeSelectorUpToDate(ctx context.Context, cr *v1alpha1.StatefulServerSet) (creationVSUpToDate bool, err error) {
+	if cr.Spec.ForProvider.Volumes == nil || len(cr.Spec.ForProvider.Volumes) == 0 {
+		e.log.Info("Skipping VolumeSelector observation as no volumes are defined in the StatefulServerSet", "ssset", cr.Name)
+		return true, nil
+	}
+
 	vsName := fmt.Sprintf(volumeSelectorName, cr.Name)
 	_, err = e.volumeSelectorController.Get(ctx, vsName, cr.Namespace)
 	if err != nil {

--- a/internal/controller/compute/statefulserverset/volumeselector_controller.go
+++ b/internal/controller/compute/statefulserverset/volumeselector_controller.go
@@ -45,6 +45,11 @@ func (k *kubeVolumeSelectorController) Get(ctx context.Context, name, ns string)
 
 // CreateOrUpdate - creates a boot volume if it does not exist, or updates it if replicas changed
 func (k *kubeVolumeSelectorController) CreateOrUpdate(ctx context.Context, cr *v1alpha1.StatefulServerSet) error {
+	if cr.Spec.ForProvider.Volumes == nil || len(cr.Spec.ForProvider.Volumes) == 0 {
+		k.log.Info("Skipping VolumeSelector creation as no volumes are defined in the StatefulServerSet", "ssset", cr.Name)
+		return nil
+	}
+
 	vsName := fmt.Sprintf(volumeSelectorName, cr.Name)
 	k.log.Info("CreateOrUpdate VolumeSelector", "name", vsName)
 	volumeSelector, err := k.Get(ctx, vsName, cr.Namespace)

--- a/internal/controller/compute/statefulserverset/volumeselector_controller.go
+++ b/internal/controller/compute/statefulserverset/volumeselector_controller.go
@@ -45,7 +45,7 @@ func (k *kubeVolumeSelectorController) Get(ctx context.Context, name, ns string)
 
 // CreateOrUpdate - creates a boot volume if it does not exist, or updates it if replicas changed
 func (k *kubeVolumeSelectorController) CreateOrUpdate(ctx context.Context, cr *v1alpha1.StatefulServerSet) error {
-	if cr.Spec.ForProvider.Volumes == nil || len(cr.Spec.ForProvider.Volumes) == 0 {
+	if len(cr.Spec.ForProvider.Volumes) == 0 {
 		k.log.Info("Skipping VolumeSelector creation as no volumes are defined in the StatefulServerSet", "ssset", cr.Name)
 		return nil
 	}

--- a/package/crds/compute.ionoscloud.crossplane.io_statefulserversets.yaml
+++ b/package/crds/compute.ionoscloud.crossplane.io_statefulserversets.yaml
@@ -941,6 +941,9 @@ spec:
                       - spec
                       type: object
                     type: array
+                    x-kubernetes-validations:
+                    - message: Number of data volumes can only be increased
+                      rule: self.size() >= oldSelf.size()
                 required:
                 - bootVolumeTemplate
                 - datacenterConfig
@@ -948,8 +951,10 @@ spec:
                 - lans
                 - replicas
                 - template
-                - volumes
                 type: object
+                x-kubernetes-validations:
+                - message: Data volumes are required once set
+                  rule: '!has(oldSelf.volumes) || has(self.volumes)'
               managementPolicies:
                 default:
                 - '*'


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane Provider IONOS Cloud!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane Provider IONOS Cloud issue. 
If yours does, you can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds:

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

I have:

- [ ] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
