### PR TITLE
[Agent] find 1 improvement on the IONOS crossplane provider

### DIFF
--- a/.npm/_logs/2026-03-12T14_05_50_269Z-debug-0.log
+++ b/.npm/_logs/2026-03-12T14_05_50_269Z-debug-0.log
@@ -1,0 +1,16 @@
+0 verbose cli /usr/local/bin/node /usr/local/bin/npm
+1 info using npm@10.8.2
+2 info using node@v20.20.1
+3 silly config load:file:/usr/local/lib/node_modules/npm/npmrc
+4 silly config load:file:/tmp/agent-workspaces/impl-b8e1351b-73f4-4eaa-bd23-615638ed976c/.npmrc
+5 silly config load:file:/usr/local/etc/npmrc
+6 verbose title npm root
+7 verbose argv "root" "--global"
+8 verbose logfile logs-max:10 dir:/tmp/agent-workspaces/impl-b8e1351b-73f4-4eaa-bd23-615638ed976c/.npm/_logs/2026-03-12T14_05_50_269Z-
+9 verbose logfile /tmp/agent-workspaces/impl-b8e1351b-73f4-4eaa-bd23-615638ed976c/.npm/_logs/2026-03-12T14_05_50_269Z-debug-0.log
+10 verbose cwd /tmp/agent-workspaces/impl-b8e1351b-73f4-4eaa-bd23-615638ed976c
+11 verbose os Linux 6.8.0-60-generic
+12 verbose node v20.20.1
+13 verbose npm  v10.8.2
+14 verbose exit 0
+15 info ok

--- a/internal/controller/k8s/k8scluster/cluster.go
+++ b/internal/controller/k8s/k8scluster/cluster.go
@@ -189,6 +189,10 @@ func createKubernetesConnectionDetails(c *externalCluster, kubeconfig string, mg
 	if err := json.Unmarshal([]byte(kubeconfig), &clientkubeconfig); err != nil {
 		c.log.Info(fmt.Sprintf("failed to unmarshal connection details. error: %v", err))
 	} else {
+		if len(clientkubeconfig.Clusters) == 0 || len(clientkubeconfig.AuthInfos) == 0 {
+			c.log.Info("kubeconfig has empty clusters or authInfos, returning partial connection details")
+			return connectionConfig
+		}
 		connectionConfig["server"] = []byte(clientkubeconfig.Clusters[0].Cluster.Server)
 		connectionConfig["caData"] = clientkubeconfig.Clusters[0].Cluster.CertificateAuthorityData
 		connectionConfig["name"] = []byte(mg.GetName())

--- a/internal/controller/k8s/k8scluster/cluster_test.go
+++ b/internal/controller/k8s/k8scluster/cluster_test.go
@@ -31,6 +31,7 @@ import (
 	ionoscloud "github.com/ionos-cloud/sdk-go/v6"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/k8s/v1alpha1"
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/internal/clients/k8s"
@@ -988,6 +989,72 @@ func TestExternalControlPlaneClientUpdate(t *testing.T) {
 			}
 			assert.Equal(t, tt.want, got)
 			assert.EqualValues(t, tt.wantCondition.Status, tt.args.GetCondition(xpv1.TypeReady).Status)
+		})
+	}
+}
+
+func TestCreateKubernetesConnectionDetails(t *testing.T) {
+	validKubeconfig := `{"apiVersion":"v1","kind":"Config","clusters":[{"cluster":{"certificate-authority-data":"Y2FkYXRh","server":"https://example.com"},"name":"test"}],"contexts":[],"users":[{"name":"admin","user":{"token":"mytoken"}}]}`
+	emptyClusters := `{"apiVersion":"v1","kind":"Config","clusters":[],"contexts":[],"users":[{"name":"admin","user":{"token":"mytoken"}}]}`
+	emptyAuthInfos := `{"apiVersion":"v1","kind":"Config","clusters":[{"cluster":{"certificate-authority-data":"Y2FkYXRh","server":"https://example.com"},"name":"test"}],"contexts":[],"users":[]}`
+
+	mg := &v1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-cluster"},
+	}
+
+	tests := []struct {
+		name       string
+		kubeconfig string
+		want       map[string][]byte
+	}{
+		{
+			name:       "Valid kubeconfig returns full connection details",
+			kubeconfig: validKubeconfig,
+			want: map[string][]byte{
+				"kubeconfig": []byte(validKubeconfig),
+				"server":     []byte("https://example.com"),
+				"caData":     []byte("cadata"),
+				"name":       []byte("my-cluster"),
+				"token":      []byte("mytoken"),
+			},
+		},
+		{
+			name:       "Empty clusters array returns partial connection details",
+			kubeconfig: emptyClusters,
+			want: map[string][]byte{
+				"kubeconfig": []byte(emptyClusters),
+			},
+		},
+		{
+			name:       "Empty authInfos array returns partial connection details",
+			kubeconfig: emptyAuthInfos,
+			want: map[string][]byte{
+				"kubeconfig": []byte(emptyAuthInfos),
+			},
+		},
+		{
+			name:       "Invalid JSON returns partial connection details",
+			kubeconfig: "not-json",
+			want: map[string][]byte{
+				"kubeconfig": []byte("not-json"),
+			},
+		},
+		{
+			name:       "Empty kubeconfig returns partial connection details",
+			kubeconfig: "",
+			want: map[string][]byte{
+				"kubeconfig": []byte(""),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &externalCluster{
+				log: utils.NewTestLogger(),
+			}
+			got := createKubernetesConnectionDetails(c, tt.kubeconfig, mg)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Agent Task

find 1 improvement on the IONOS crossplane provider

## Implementation Plan

Here is the implementation plan:

---

## Improvement: Add bounds checks to prevent index-out-of-range panic in K8s cluster connection details

### Problem

In `internal/controller/k8s/k8scluster/cluster.go:191-195`, the function `createKubernetesConnectionDetails` accesses `clientkubeconfig.Clusters[0]` and `clientkubeconfig.AuthInfos[0]` **without verifying the slices are non-empty**. If the IONOS API returns a kubeconfig that deserializes into valid JSON but has empty `clusters` or `users` arrays (e.g., during a transient API issue or a race with cluster provisioning), the crossplane provider will **panic with an index out of range**, crashing the controller pod.

### Files to modify

1. **`internal/controller/k8s/k8scluster/cluster.go`** (~lines 188-196)  
   - Add length checks on `clientkubeconfig.Clusters` and `clientkubeconfig.AuthInfos` before accessing index `[0]`
   - Log a warning and return the partial `connectionConfig` (with just the raw kubeconfig) if the slices are empty, instead of panicking

2. **`internal/controller/k8s/k8scluster/cluster_test.go`** (new or existing test file)  
   - Add unit tests for `createKubernetesConnectionDetails` covering:
     - Valid kubeconfig (happy path)
     - Empty `Clusters` array
     - Empty `AuthInfos` array
     - Invalid JSON (already handled, but good to cover)

### Step-by-step approach

1. In `createKubernetesConnectionDetails`, wrap the slice accesses in bounds checks:
   ```
   if len(clientkubeconfig.Clusters) == 0 || len(clientkubeconfig.AuthInfos) == 0 {
       c.log.Info("kubeconfig has empty clusters or authInfos, returning partial connection details")
       return connectionConfig
   }
   ```
2. Add corresponding unit tests to validate both the guarded and unguarded paths.
3. Run existing tests (`go test ./internal/controller/k8s/k8scluster/...`) to confirm no regressions.

### Branch name

```
agent/fix-kubeconfig-index-bounds-check
```

---
_Created by AI Wingman Agent_