### PR TITLE
fix: omit nodeCount from nodepool PUT when autoscaling is enabled

### DIFF
--- a/internal/clients/k8s/k8snodepool/nodepool.go
+++ b/internal/clients/k8s/k8snodepool/nodepool.go
@@ -183,7 +183,6 @@ func GenerateUpdateK8sNodePoolInput(cr *v1alpha1.NodePool, publicIps []string) *
 	serverType := sdkgo.KubernetesNodePoolServerType(cr.Spec.ForProvider.ServerType)
 	instanceUpdateInput := sdkgo.KubernetesNodePoolForPut{
 		Properties: &sdkgo.KubernetesNodePoolPropertiesForPut{
-			NodeCount:  &cr.Spec.ForProvider.NodeCount,
 			ServerType: &serverType,
 		},
 	}
@@ -197,6 +196,8 @@ func GenerateUpdateK8sNodePoolInput(cr *v1alpha1.NodePool, publicIps []string) *
 			MinNodeCount: &cr.Spec.ForProvider.AutoScaling.MinNodeCount,
 			MaxNodeCount: &cr.Spec.ForProvider.AutoScaling.MaxNodeCount,
 		})
+	} else {
+		instanceUpdateInput.Properties.NodeCount = &cr.Spec.ForProvider.NodeCount
 	}
 	if !utils.IsEmptyValue(reflect.ValueOf(cr.Spec.ForProvider.Annotations)) {
 		instanceUpdateInput.Properties.SetAnnotations(cr.Spec.ForProvider.Annotations)

--- a/internal/clients/k8s/k8snodepool/nodepool_test.go
+++ b/internal/clients/k8s/k8snodepool/nodepool_test.go
@@ -9,6 +9,61 @@ import (
 	"github.com/ionos-cloud/crossplane-provider-ionoscloud/apis/k8s/v1alpha1"
 )
 
+func TestGenerateUpdateK8sNodePoolInput_AutoScalingOmitsNodeCount(t *testing.T) {
+	cr := &v1alpha1.NodePool{
+		Spec: v1alpha1.NodePoolSpec{
+			ForProvider: v1alpha1.NodePoolParameters{
+				Name:       "test-pool",
+				ServerType: "VCPU",
+				NodeCount:  3,
+				AutoScaling: v1alpha1.KubernetesAutoScaling{
+					MinNodeCount: 2,
+					MaxNodeCount: 10,
+				},
+			},
+		},
+	}
+
+	result := GenerateUpdateK8sNodePoolInput(cr, nil)
+
+	if result.Properties.NodeCount != nil {
+		t.Errorf("NodeCount should be nil when AutoScaling is set, got %d", *result.Properties.NodeCount)
+	}
+	if result.Properties.AutoScaling == nil {
+		t.Fatal("AutoScaling should be set")
+	}
+	if *result.Properties.AutoScaling.MinNodeCount != 2 {
+		t.Errorf("MinNodeCount = %d, want 2", *result.Properties.AutoScaling.MinNodeCount)
+	}
+	if *result.Properties.AutoScaling.MaxNodeCount != 10 {
+		t.Errorf("MaxNodeCount = %d, want 10", *result.Properties.AutoScaling.MaxNodeCount)
+	}
+}
+
+func TestGenerateUpdateK8sNodePoolInput_NoAutoScalingIncludesNodeCount(t *testing.T) {
+	cr := &v1alpha1.NodePool{
+		Spec: v1alpha1.NodePoolSpec{
+			ForProvider: v1alpha1.NodePoolParameters{
+				Name:       "test-pool",
+				ServerType: "VCPU",
+				NodeCount:  5,
+			},
+		},
+	}
+
+	result := GenerateUpdateK8sNodePoolInput(cr, nil)
+
+	if result.Properties.NodeCount == nil {
+		t.Fatal("NodeCount should be set when AutoScaling is not configured")
+	}
+	if *result.Properties.NodeCount != 5 {
+		t.Errorf("NodeCount = %d, want 5", *result.Properties.NodeCount)
+	}
+	if result.Properties.AutoScaling != nil {
+		t.Errorf("AutoScaling should be nil when not configured")
+	}
+}
+
 func TestIsNodePoolUpToDate(t *testing.T) {
 	type args struct {
 		cr       *v1alpha1.NodePool


### PR DESCRIPTION
Currently nodeCount is not used to determine if a nodepool needs updating, but it IS still sent in the PUT request if the nodepool needs updating for any other reason leading to crossplane fighting with the mk8s autoscaler. this is a change to add tests and fix it