### PR TITLE
doc: update version 1.2.5

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.2.5] (August 2026)
+### Fixes:
+- Omit `nodeCount` from the k8s nodepool update request when autoscaling is enabled, so the autoscaled node count is no longer reset on update.
+
+## [1.2.4] (May 2026)
+### Fixes:
+- Keep the same IPs from previous versions when recreating bootvolumes.
+- ICNAS-571: Change the comparison method for the `NicMultiQueue` property.
+### Chore
+- Add notification job to `ci-weekly`.
+### Documentation:
+- Add note about using the generated provider.
+
 ## [1.2.3] (February 2026)
 - Fix lan update when `Pcc`when updating from nil
 - Update trivy to v0.35.0


### PR DESCRIPTION
Prepares the CHANGELOG for the `v1.2.5` release.

## What's in it
- **[1.2.5]** — new entry for the only commit since `v1.2.4`: omit `nodeCount` from the k8s nodepool update request when autoscaling is enabled (#402).
- **[1.2.4]** — backfilled. This section was never added when `v1.2.4` was tagged, so the file jumped straight from `1.2.3` to the unreleased changes. Covers #397, #400, #401 and #398.

Docs only, no code changes. Once this is merged, `v1.2.5` gets tagged on the resulting master commit and the CD workflow is dispatched against that tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)