### PR TITLE
feat: increase reboot timeout when using statemap

### DIFF
--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -15,7 +15,7 @@ import (
 const ResourceReadyTimeout = 50 * time.Minute
 
 // VMRebootTimeout time to wait for a VM to reboot and report as ready after a failover
-const VMRebootTimeout = 120 * time.Minute
+const VMRebootTimeout = 24 * time.Hour
 
 // ServerSetReadyTimeout time to wait for serverset to be ready
 const ServerSetReadyTimeout = 3 * time.Hour


### PR DESCRIPTION
### Description of your changes

We noticed that resync can take quite some time for large clusters with high write load, and we would like to increase the timeout.

## Checklist

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [ ] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [ ] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [ ] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [ ] Check Sonar Cloud Scan
- [ ] Update Github or Jira Issue
