### PR TITLE
[ICNAS-870] support mTLS client certificates for the compute API endpoint

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,9 +102,9 @@ is also set, the client certificate is still presented and the pinned fingerprin
 enforced - both features work together.
 
 ```bash
-export BASE64_CLIENT_CERT=$(base64 -w0 client.pem)
-export BASE64_CLIENT_KEY=$(base64 -w0 client-key.pem)
-export BASE64_CA_CERT=$(base64 -w0 ca.pem)
+export BASE64_CLIENT_CERT=$(base64 < client.pem | tr -d '\n')
+export BASE64_CLIENT_KEY=$(base64 < client-key.pem | tr -d '\n')
+export BASE64_CA_CERT=$(base64 < ca.pem | tr -d '\n')
 kubectl create secret generic --namespace crossplane-system example-provider-secret --from-literal=credentials="{\"token\":\"${IONOS_TOKEN}\",\"client_cert\":\"${BASE64_CLIENT_CERT}\",\"client_key\":\"${BASE64_CLIENT_KEY}\",\"ca_cert\":\"${BASE64_CA_CERT}\"}"
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ To create the Provider secret, you can use either of the following methods:
 
 * [<mark style="color:blue;">Using username and password</mark>](#using-username-and-password)
 * [<mark style="color:blue;">Using token</mark>](#using-token)
+* [<mark style="color:blue;">Using mTLS for the compute/cloud API endpoint</mark>](#using-mtls-for-the-computecloud-api-endpoint)
 
 {% hint style="info" %}
 **Note:** We recommend **using token** to create the Provider secret.
@@ -79,6 +80,34 @@ Run the following command:
 ```bash
 kubectl create secret generic --namespace crossplane-system example-provider-secret --from-literal=credentials="{\"token\":\"${IONOS_TOKEN}\"}"
 ```
+
+#### Using mTLS for the compute/cloud API endpoint
+
+If the compute/cloud API endpoint you point the provider at enforces mutual TLS (mTLS) client
+certificate verification, you can optionally have the provider present a client certificate by
+adding the following fields to the credentials JSON, in addition to `user`/`password` or `token`:
+
+| **Field**     | **Description**                                                                                                                     |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| `client_cert` | PEM encoded client certificate, base64 encoded (like `password`). Requires `client_key` to also be set.                              |
+| `client_key`  | PEM encoded private key matching `client_cert`, base64 encoded (like `password`). Requires `client_cert` to also be set.              |
+| `ca_cert`     | Optional PEM encoded CA certificate to trust in addition to the system root pool, base64 encoded. Requires `client_cert`/`client_key` to also be set - setting `ca_cert` on its own is rejected as an error. |
+
+This only affects the compute/cloud API client - it has no effect on DBaaS Postgres/Mongo, and it
+does not change the default endpoint (`api.ionos.com`) or any existing behavior when these fields
+are not set.
+
+If `IONOS_PINNED_CERT` (see [Authentication on IONOS Cloud](../README.md#authentication-on-ionos-cloud))
+is also set, the client certificate is still presented and the pinned fingerprint is still
+enforced - both features work together.
+
+```bash
+export BASE64_CLIENT_CERT=$(base64 -w0 client.pem)
+export BASE64_CLIENT_KEY=$(base64 -w0 client-key.pem)
+export BASE64_CA_CERT=$(base64 -w0 ca.pem)
+kubectl create secret generic --namespace crossplane-system example-provider-secret --from-literal=credentials="{\"token\":\"${IONOS_TOKEN}\",\"client_cert\":\"${BASE64_CLIENT_CERT}\",\"client_key\":\"${BASE64_CLIENT_KEY}\",\"ca_cert\":\"${BASE64_CA_CERT}\"}"
+```
+
 {% hint style="info" %}
 **Note:** 
 * You can overwrite the default IONOS Cloud API endpoint, by setting the credentials to: `credentials="{\"host_url\":\"${IONOS_API_URL}\"}"`.

--- a/examples/example.md
+++ b/examples/example.md
@@ -124,6 +124,14 @@ OR
 **Note:** You can overwrite the default IONOS Cloud API endpoint, by setting ``host_url`` to: ``--from-literal=credentials="{\"host_url\":\"${IONOS_API_URL}\"}"``.
 {% endhint %}
 
+{% hint style="info" %}
+**Note:** If the compute/cloud API endpoint enforces mutual TLS (mTLS), you can optionally have
+the provider present a client certificate by adding ``client_cert``/``client_key`` (and
+optionally ``ca_cert``) to the credentials JSON, all base64 encoded like ``password``. See
+[<mark style="color:blue;">Crossplane Provider IONOS Cloud</mark>](../docs/README.md#using-mtls-for-the-computecloud-api-endpoint)
+for the full field reference and an example.
+{% endhint %}
+
 ### Install Crossplane Provider for IONOS Cloud
 
 To install Crossplane Provider for IONOS Cloud, run the following command:

--- a/internal/clients/ionoscloud.go
+++ b/internal/clients/ionoscloud.go
@@ -190,12 +190,12 @@ func buildComputeMTLSHTTPClient(creds credentials) (*http.Client, error) {
 // caller built and handed to sdkgo.NewAPIClient, and that call mutates its Transport field in
 // place, so by the time this function runs the original Transport is already gone from that
 // object too.
-func reapplyMTLSAfterPinning(cfg *sdkgo.Configuration, mtlsTLSConfig *tls.Config) error {
+func reapplyMTLSAfterPinning(cfg *sdkgo.Configuration, mtlsTLSConfig *tls.Config) {
 	pkFingerprint := os.Getenv(sdkgo.IonosPinnedCertEnvVar)
 	if pkFingerprint == "" {
 		// sdkgo.NewAPIClient only touches cfg.HTTPClient.Transport when the pinning env var is
 		// set, so our Transport is still intact - nothing to repair.
-		return nil
+		return
 	}
 
 	tlsConfig := mtlsTLSConfig.Clone()
@@ -206,7 +206,6 @@ func reapplyMTLSAfterPinning(cfg *sdkgo.Configuration, mtlsTLSConfig *tls.Config
 		TLSClientConfig: tlsConfig,
 		DialTLSContext:  pinnedCertDialTLSContext(pkFingerprint, tlsConfig),
 	}
-	return nil
 }
 
 // pinnedCertDialTLSContext returns a TLS dialer equivalent to sdkgo's own certificate-pinning
@@ -225,12 +224,17 @@ func pinnedCertDialTLSContext(fingerprint string, base *tls.Config) func(ctx con
 	tlsConfig := base.Clone()
 	tlsConfig.InsecureSkipVerify = true
 
-	return func(_ context.Context, network, addr string) (net.Conn, error) {
-		conn, err := tls.Dial(network, addr, tlsConfig)
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := (&tls.Dialer{Config: tlsConfig}).DialContext(ctx, network, addr)
 		if err != nil {
 			return nil, err
 		}
-		if err := verifyPinnedCertFingerprint(trimmed, conn.ConnectionState().PeerCertificates); err != nil {
+		tlsConn, ok := conn.(*tls.Conn)
+		if !ok {
+			_ = conn.Close()
+			return nil, fmt.Errorf("pinned cert dial: unexpected connection type %T", conn)
+		}
+		if err := verifyPinnedCertFingerprint(trimmed, tlsConn.ConnectionState().PeerCertificates); err != nil {
 			_ = conn.Close()
 			return nil, err
 		}
@@ -307,9 +311,7 @@ func NewIonosClients(data []byte) (*IonosServices, error) {
 		// sdkgo.NewAPIClient silently discards the mTLS Transport we just configured whenever
 		// IONOS_PINNED_CERT is also set - see reapplyMTLSAfterPinning for why and how this is
 		// repaired.
-		if err := reapplyMTLSAfterPinning(computeEngineClient.GetConfig(), computeMTLSTLSConfig); err != nil {
-			return nil, fmt.Errorf("failed to configure mtls for compute client: %w", err)
-		}
+		reapplyMTLSAfterPinning(computeEngineClient.GetConfig(), computeMTLSTLSConfig)
 	}
 
 	return &IonosServices{

--- a/internal/clients/ionoscloud.go
+++ b/internal/clients/ionoscloud.go
@@ -133,7 +133,7 @@ func buildComputeMTLSHTTPClient(creds credentials) (*http.Client, error) {
 		if err != nil || pool == nil {
 			pool = x509.NewCertPool()
 		}
-		if ok := pool.AppendCertsFromPEM(caPEM); !ok {
+		if !pool.AppendCertsFromPEM(caPEM) {
 			return nil, fmt.Errorf("mtls setup: failed to parse ca_cert as PEM")
 		}
 		rootCAs = pool

--- a/internal/clients/ionoscloud.go
+++ b/internal/clients/ionoscloud.go
@@ -160,10 +160,15 @@ func buildComputeMTLSHTTPClient(creds credentials) (*http.Client, error) {
 		tlsConfig.RootCAs = rootCAs
 	}
 
+	// Clone http.DefaultTransport rather than starting from a zero-valued *http.Transport, so we
+	// keep its defaults (ProxyFromEnvironment, idle/TLS-handshake timeouts, HTTP/2 settings, ...)
+	// and only override TLSClientConfig - a bare &http.Transport{} would silently drop all of
+	// those, e.g. breaking outbound proxy support for anyone running the provider behind one.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+
 	return &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: tlsConfig,
-		},
+		Transport: transport,
 	}, nil
 }
 
@@ -202,10 +207,12 @@ func reapplyMTLSAfterPinning(cfg *sdkgo.Configuration, mtlsTLSConfig *tls.Config
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = &http.Client{}
 	}
-	cfg.HTTPClient.Transport = &http.Transport{
-		TLSClientConfig: tlsConfig,
-		DialTLSContext:  pinnedCertDialTLSContext(pkFingerprint, tlsConfig),
-	}
+	// Same reasoning as buildComputeMTLSHTTPClient: clone http.DefaultTransport instead of
+	// starting from a zero-valued *http.Transport, to keep its non-TLS defaults intact.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	transport.DialTLSContext = pinnedCertDialTLSContext(pkFingerprint, tlsConfig)
+	cfg.HTTPClient.Transport = transport
 }
 
 // pinnedCertDialTLSContext returns a TLS dialer equivalent to sdkgo's own certificate-pinning

--- a/internal/clients/ionoscloud.go
+++ b/internal/clients/ionoscloud.go
@@ -1,10 +1,17 @@
 package clients
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -70,6 +77,179 @@ type credentials struct {
 	// HostURL is the baseURL of the IONOS Cloud API.
 	// It can be used for overwriting the default endpoint. Optional.
 	HostURL string `json:"host_url"`
+
+	// ClientCertificate is a PEM encoded client (leaf) certificate presented for mutual TLS
+	// (mTLS) authentication against the compute/cloud API endpoint, e.g. an internal endpoint
+	// that enforces client certificate verification. Optional; requires ClientKey to also be
+	// set. Like Password, it must be base64 encoded to survive JSON string escaping.
+	ClientCertificate string `json:"client_cert"`
+
+	// ClientKey is the PEM encoded private key matching ClientCertificate. Optional; requires
+	// ClientCertificate to also be set. Must be base64 encoded, like Password.
+	ClientKey string `json:"client_key"`
+
+	// CACertificate is an optional PEM encoded CA certificate to trust in addition to the
+	// system root pool when validating the compute/cloud API's server certificate. Useful when
+	// the mTLS endpoint's server certificate is not publicly trusted. Optional. Must be base64
+	// encoded, like Password. Only meaningful together with ClientCertificate/ClientKey - it is
+	// rejected as an error if set without them, since it would otherwise have no effect. See
+	// buildComputeMTLSHTTPClient.
+	CACertificate string `json:"ca_cert"`
+}
+
+// buildComputeMTLSHTTPClient builds an *http.Client configured to present a client certificate
+// for mutual TLS (mTLS) when talking to the compute/cloud API. It returns (nil, nil) whenever no
+// MTLS credentials are configured, so callers can leave the SDK's HTTPClient field untouched
+// (nil), which preserves today's default behavior (sdkgo.NewAPIClient falls back to
+// http.DefaultClient).
+func buildComputeMTLSHTTPClient(creds credentials) (*http.Client, error) {
+	hasCert := creds.ClientCertificate != ""
+	hasKey := creds.ClientKey != ""
+	hasCA := creds.CACertificate != ""
+
+	if !hasCert && !hasKey && !hasCA {
+		return nil, nil
+	}
+	if hasCert != hasKey {
+		return nil, fmt.Errorf("mtls setup: client_cert and client_key must both be set together")
+	}
+
+	// A CA cert is only meaningful in combination with a client cert/key: this feature exists to
+	// let the provider present a client certificate, and ca_cert only adjusts the trust pool used
+	// while doing so. A CA-only config (no client_cert/client_key) can't have any effect, so rather
+	// than silently ignoring it (which would leave an operator's ca_cert setting inert with no
+	// indication why) we reject it explicitly - it is almost certainly a misconfiguration.
+	if hasCA && !hasCert {
+		return nil, fmt.Errorf("mtls setup: ca_cert has no effect without client_cert/client_key also being set")
+	}
+
+	var rootCAs *x509.CertPool
+	if hasCA {
+		caPEM, err := base64.StdEncoding.DecodeString(creds.CACertificate)
+		if err != nil {
+			return nil, fmt.Errorf("mtls setup: failed to decode ca_cert: %w", err)
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		if ok := pool.AppendCertsFromPEM(caPEM); !ok {
+			return nil, fmt.Errorf("mtls setup: failed to parse ca_cert as PEM")
+		}
+		rootCAs = pool
+	}
+
+	certPEM, err := base64.StdEncoding.DecodeString(creds.ClientCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("mtls setup: failed to decode client_cert: %w", err)
+	}
+	keyPEM, err := base64.StdEncoding.DecodeString(creds.ClientKey)
+	if err != nil {
+		return nil, fmt.Errorf("mtls setup: failed to decode client_key: %w", err)
+	}
+
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("mtls setup: failed to load client certificate/key pair: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	if rootCAs != nil {
+		tlsConfig.RootCAs = rootCAs
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: tlsConfig,
+		},
+	}, nil
+}
+
+// reapplyMTLSAfterPinning repairs the compute client's Transport after sdkgo.NewAPIClient has run.
+//
+// sdkgo.NewAPIClient (github.com/ionos-cloud/sdk-go/v6@v6.3.4/client.go) unconditionally does
+// `cfg.HTTPClient.Transport = httpTransport` - replacing the whole Transport with a bare
+// *http.Transport carrying only a pinning DialTLSContext - whenever the IONOS_PINNED_CERT env var
+// is set, regardless of whether cfg.HTTPClient was already customized. That silently discards the
+// TLSClientConfig (client certificate, custom RootCAs) buildComputeMTLSHTTPClient configured
+// above, so the provider stops presenting the client certificate the moment cert pinning is also
+// enabled.
+//
+// It is not enough to reassign our original Transport back onto the config afterward: the SDK's
+// own pinning dialer (sdkgo.AddPinnedCert/addPinnedCertVerification) does its TLS handshake with a
+// hardcoded fresh *tls.Config that never carries client certificates, so simply layering the SDK's
+// helper on top of our Transport would still drop the client cert. Instead, when both features are
+// configured together, this builds a single DialTLSContext that dials with our own tls.Config
+// (Certificates and RootCAs intact) and then performs the same manual fingerprint verification the
+// SDK's pinning feature does, so mTLS and certificate pinning both take effect at once.
+//
+// mtlsTLSConfig must be captured by the caller *before* calling sdkgo.NewAPIClient, not read back
+// off cfg.HTTPClient afterward: cfg.HTTPClient here is the very same *http.Client pointer the
+// caller built and handed to sdkgo.NewAPIClient, and that call mutates its Transport field in
+// place, so by the time this function runs the original Transport is already gone from that
+// object too.
+func reapplyMTLSAfterPinning(cfg *sdkgo.Configuration, mtlsTLSConfig *tls.Config) error {
+	pkFingerprint := os.Getenv(sdkgo.IonosPinnedCertEnvVar)
+	if pkFingerprint == "" {
+		// sdkgo.NewAPIClient only touches cfg.HTTPClient.Transport when the pinning env var is
+		// set, so our Transport is still intact - nothing to repair.
+		return nil
+	}
+
+	tlsConfig := mtlsTLSConfig.Clone()
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{}
+	}
+	cfg.HTTPClient.Transport = &http.Transport{
+		TLSClientConfig: tlsConfig,
+		DialTLSContext:  pinnedCertDialTLSContext(pkFingerprint, tlsConfig),
+	}
+	return nil
+}
+
+// pinnedCertDialTLSContext returns a TLS dialer equivalent to sdkgo's own certificate-pinning
+// dialer (addPinnedCertVerification in sdk-go/v6's client.go), except that it dials using the
+// given base tls.Config - so any client certificate/RootCAs it carries are still presented/used -
+// rather than a hardcoded empty one. Like the SDK's version, normal chain verification is disabled
+// in favor of the manual fingerprint check below, since that is the trust mechanism cert pinning
+// implements; the client certificate is still presented during the handshake regardless of
+// InsecureSkipVerify, which only disables verification of the *server's* certificate.
+func pinnedCertDialTLSContext(fingerprint string, base *tls.Config) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	// Fingerprints can be supplied with ':' or ' ' separators, matching sdk-go/v6's own handling.
+	trimmed := []byte(fingerprint)
+	trimmed = bytes.ReplaceAll(trimmed, []byte(":"), nil)
+	trimmed = bytes.ReplaceAll(trimmed, []byte(" "), nil)
+
+	tlsConfig := base.Clone()
+	tlsConfig.InsecureSkipVerify = true
+
+	return func(_ context.Context, network, addr string) (net.Conn, error) {
+		conn, err := tls.Dial(network, addr, tlsConfig)
+		if err != nil {
+			return nil, err
+		}
+		if err := verifyPinnedCertFingerprint(trimmed, conn.ConnectionState().PeerCertificates); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		return conn, nil
+	}
+}
+
+// verifyPinnedCertFingerprint mirrors sdk-go/v6's unexported verifyPinnedCert: it accepts the
+// connection if any non-CA peer certificate's SHA-256 fingerprint matches.
+func verifyPinnedCertFingerprint(fingerprint []byte, peerCerts []*x509.Certificate) error {
+	for _, cert := range peerCerts {
+		sum := sha256.Sum256(cert.Raw)
+		hexSum := make([]byte, hex.EncodedLen(len(sum)))
+		hex.Encode(hexSum, sum[:])
+		if !cert.IsCA && bytes.EqualFold(hexSum, fingerprint) {
+			return nil
+		}
+	}
+	return fmt.Errorf("remote server presented a certificate which does not match the provided fingerprint")
 }
 
 // NewIonosClients creates a IonosService from the given data. The data must be a json struct with the fields `User`,
@@ -92,6 +272,22 @@ func NewIonosClients(data []byte) (*IonosServices, error) {
 	if apiHostURL == "" && ionosAPIEndpoint != "" {
 		apiHostURL = ionosAPIEndpoint
 	}
+
+	// Optional mTLS client certificate for the compute/cloud API endpoint. Only ComputeClient
+	// uses this - DBaaS Postgres/Mongo live on different domains/products and are out of scope.
+	computeHTTPClient, err := buildComputeMTLSHTTPClient(creds)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure mtls for compute client: %w", err)
+	}
+	// Captured now, before sdkgo.NewAPIClient runs: see reapplyMTLSAfterPinning for why this
+	// cannot be read back off computeHTTPClient after that call.
+	var computeMTLSTLSConfig *tls.Config
+	if computeHTTPClient != nil {
+		if tr, ok := computeHTTPClient.Transport.(*http.Transport); ok {
+			computeMTLSTLSConfig = tr.TLSClientConfig
+		}
+	}
+
 	// DBaaS Mongo Client
 	dbaasMongoConfig := mongo.NewConfiguration(creds.User, string(decodedPW), creds.Token, apiHostURL)
 	dbaasMongoConfig.UserAgent = fmt.Sprintf("%v/%v_%v", UserAgent, version.Version, dbaasMongoConfig.UserAgent)
@@ -103,7 +299,18 @@ func NewIonosClients(data []byte) (*IonosServices, error) {
 	// Compute Engine Client
 	computeEngineConfig := sdkgo.NewConfiguration(creds.User, string(decodedPW), creds.Token, apiHostURL)
 	computeEngineConfig.UserAgent = fmt.Sprintf("%v/%v_%v", UserAgent, version.Version, computeEngineConfig.UserAgent)
+	if computeHTTPClient != nil {
+		computeEngineConfig.HTTPClient = computeHTTPClient
+	}
 	computeEngineClient := sdkgo.NewAPIClient(computeEngineConfig)
+	if computeMTLSTLSConfig != nil {
+		// sdkgo.NewAPIClient silently discards the mTLS Transport we just configured whenever
+		// IONOS_PINNED_CERT is also set - see reapplyMTLSAfterPinning for why and how this is
+		// repaired.
+		if err := reapplyMTLSAfterPinning(computeEngineClient.GetConfig(), computeMTLSTLSConfig); err != nil {
+			return nil, fmt.Errorf("failed to configure mtls for compute client: %w", err)
+		}
+	}
 
 	return &IonosServices{
 		DBaaSMongoClient:    dbaasMongoClient,

--- a/internal/clients/ionoscloud_test.go
+++ b/internal/clients/ionoscloud_test.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -484,7 +485,9 @@ func TestNewIonosClient_MTLSWithCertPinning(t *testing.T) {
 		hc := svc.ComputeClient.GetConfig().HTTPClient
 		require.NotNil(t, hc)
 
-		resp, err := hc.Get(srv.URL)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		resp, err := hc.Do(req)
 		require.NoError(t, err, "handshake must succeed: fingerprint matches and client cert is presented")
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -504,7 +507,12 @@ func TestNewIonosClient_MTLSWithCertPinning(t *testing.T) {
 		hc := svc.ComputeClient.GetConfig().HTTPClient
 		require.NotNil(t, hc)
 
-		_, err = hc.Get(srv.URL)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		resp, err := hc.Do(req)
+		if resp != nil {
+			defer resp.Body.Close()
+		}
 		assert.Error(t, err, "handshake must fail when the pinned fingerprint does not match the server certificate")
 	})
 }

--- a/internal/clients/ionoscloud_test.go
+++ b/internal/clients/ionoscloud_test.go
@@ -1,8 +1,20 @@
 package clients
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -39,11 +51,59 @@ func setDbaaSDefaults(cfg *shared.Configuration) {
 
 }
 
+// generateTestCertPEM generates a fresh, self-signed ECDSA certificate/key pair at test-run
+// time, PEM encoded, for use as either a client certificate or a CA certificate in the MTLS
+// tests below. It returns the raw (non-base64) PEM bytes plus the parsed certificate.
+func generateTestCertPEM(t *testing.T, commonName string, isCA bool) (certPEM, keyPEM []byte, cert *x509.Certificate) {
+	t.Helper()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  isCA,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	cert, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	return certPEM, keyPEM, cert
+}
+
+// b64 base64-encodes raw bytes, matching the convention used for the `password` field.
+func b64(in []byte) string {
+	return base64.StdEncoding.EncodeToString(in)
+}
+
 func TestNewIonosClient(t *testing.T) {
 
 	type args struct {
 		data []byte
 	}
+
+	clientCertPEM, clientKeyPEM, clientCert := generateTestCertPEM(t, "provider-client", false)
+	caCertPEM, _, caCert := generateTestCertPEM(t, "test-ca", true)
+	_, unrelatedKeyPEM, _ := generateTestCertPEM(t, "unrelated-key", false)
+
 	tests := []struct {
 		name              string
 		args              args
@@ -51,6 +111,12 @@ func TestNewIonosClient(t *testing.T) {
 		wantComputeConfig *ionos.Configuration
 		wantDbaasConfig   *shared.Configuration
 		wantErr           bool
+		// checkComputeHTTPClient, when set, replaces the plain assert.Equal comparison of
+		// ComputeClient's HTTPClient with targeted assertions on the TLS bits (a real
+		// tls.Config carrying private key/pool material cannot be reliably deep-equal compared).
+		// wantComputeConfig.HTTPClient is still used as the baseline for the rest of the struct
+		// comparison; only the HTTPClient field itself is swapped out before that comparison.
+		checkComputeHTTPClient func(t *testing.T, hc *http.Client)
 	}{
 		{
 			name:              "nil data",
@@ -146,6 +212,179 @@ func TestNewIonosClient(t *testing.T) {
 			wantDbaasConfig:   nil,
 			wantErr:           true,
 		},
+		{
+			name: "mtls client cert and key",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s", "client_key": "%s"}`,
+					b64(clientCertPEM), b64(clientKeyPEM),
+				)),
+			},
+			wantComputeConfig: func() *ionos.Configuration {
+				cfg := ionos.NewConfiguration("username", "password", "", "")
+				setComputeDefaults(cfg)
+				return cfg
+			}(),
+			wantDbaasConfig: func() *shared.Configuration {
+				cfg := shared.NewConfiguration("username", "password", "", "")
+				setDbaaSDefaults(cfg)
+				cfg.Servers = shared.ServerConfigurations{
+					{
+						URL:         "https://api.ionos.com/databases/postgresql",
+						Description: "Production",
+					},
+				}
+				return cfg
+			}(),
+			wantErr: false,
+			checkComputeHTTPClient: func(t *testing.T, hc *http.Client) {
+				require.NotNil(t, hc)
+				tr, ok := hc.Transport.(*http.Transport)
+				require.True(t, ok, "expected an *http.Transport carrying the TLS client cert")
+				require.NotNil(t, tr.TLSClientConfig)
+				require.Len(t, tr.TLSClientConfig.Certificates, 1)
+				assert.Equal(t, clientCert.Raw, tr.TLSClientConfig.Certificates[0].Certificate[0])
+				assert.Nil(t, tr.TLSClientConfig.RootCAs, "no ca_cert was supplied, RootCAs must stay nil")
+			},
+		},
+		{
+			name: "mtls client cert, key and ca",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s", "client_key": "%s", "ca_cert": "%s"}`,
+					b64(clientCertPEM), b64(clientKeyPEM), b64(caCertPEM),
+				)),
+			},
+			wantComputeConfig: func() *ionos.Configuration {
+				cfg := ionos.NewConfiguration("username", "password", "", "")
+				setComputeDefaults(cfg)
+				return cfg
+			}(),
+			wantDbaasConfig: func() *shared.Configuration {
+				cfg := shared.NewConfiguration("username", "password", "", "")
+				setDbaaSDefaults(cfg)
+				cfg.Servers = shared.ServerConfigurations{
+					{
+						URL:         "https://api.ionos.com/databases/postgresql",
+						Description: "Production",
+					},
+				}
+				return cfg
+			}(),
+			wantErr: false,
+			checkComputeHTTPClient: func(t *testing.T, hc *http.Client) {
+				require.NotNil(t, hc)
+				tr, ok := hc.Transport.(*http.Transport)
+				require.True(t, ok, "expected an *http.Transport carrying the TLS client cert")
+				require.NotNil(t, tr.TLSClientConfig)
+				require.Len(t, tr.TLSClientConfig.Certificates, 1)
+				assert.Equal(t, clientCert.Raw, tr.TLSClientConfig.Certificates[0].Certificate[0])
+				require.NotNil(t, tr.TLSClientConfig.RootCAs, "ca_cert was supplied, RootCAs must be set")
+
+				wantPool, err := x509.SystemCertPool()
+				if err != nil || wantPool == nil {
+					wantPool = x509.NewCertPool()
+				}
+				wantPool.AddCert(caCert)
+				assert.True(t, tr.TLSClientConfig.RootCAs.Equal(wantPool), "RootCAs must be the system pool plus the supplied CA")
+			},
+		},
+		{
+			name: "mtls client cert without key",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s"}`,
+					b64(clientCertPEM),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "mtls client key without cert",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_key": "%s"}`,
+					b64(clientKeyPEM),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "mtls ca cert without client cert/key",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "ca_cert": "%s"}`,
+					b64(caCertPEM),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "mtls mismatched client cert and key",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s", "client_key": "%s"}`,
+					b64(clientCertPEM), b64(unrelatedKeyPEM),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "mtls malformed base64 client cert",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "not-valid-base64!", "client_key": "%s"}`,
+					b64(clientKeyPEM),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "mtls invalid PEM client cert",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s", "client_key": "%s"}`,
+					b64([]byte("not a real certificate")), b64(clientKeyPEM),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "mtls malformed base64 ca cert",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s", "client_key": "%s", "ca_cert": "not-valid-base64!"}`,
+					b64(clientCertPEM), b64(clientKeyPEM),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
+		{
+			name: "mtls invalid PEM ca cert",
+			args: args{
+				data: []byte(fmt.Sprintf(
+					`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s", "client_key": "%s", "ca_cert": "%s"}`,
+					b64(clientCertPEM), b64(clientKeyPEM), b64([]byte("not a real ca certificate")),
+				)),
+			},
+			wantComputeConfig: nil,
+			wantDbaasConfig:   nil,
+			wantErr:           true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -174,6 +413,16 @@ func TestNewIonosClient(t *testing.T) {
 				ccfg.Logger = nil
 				tt.wantComputeConfig.Logger = nil
 
+				if tt.checkComputeHTTPClient != nil {
+					tt.checkComputeHTTPClient(t, ccfg.HTTPClient)
+					// The TLS bits were just verified above with targeted assertions since a real
+					// tls.Config (private key material, cert pools) cannot be reliably
+					// deep-equal compared. Swap in the baseline HTTPClient so the rest of the
+					// Configuration struct (UserAgent, etc.) can still be compared with
+					// assert.Equal below.
+					ccfg.HTTPClient = tt.wantComputeConfig.HTTPClient
+				}
+
 				assert.Equal(t, tt.wantComputeConfig, ccfg)
 				assert.Equal(t, tt.wantDbaasConfig, dcfg)
 			} else {
@@ -181,6 +430,83 @@ func TestNewIonosClient(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewIonosClient_MTLSWithCertPinning verifies that when both a client certificate (mTLS) and
+// IONOS_PINNED_CERT (certificate pinning) are configured together, the resulting compute HTTP
+// client still presents the client certificate on the wire, and still enforces the pinned
+// fingerprint. sdkgo.NewAPIClient unconditionally overwrites cfg.HTTPClient.Transport with a bare
+// pinning-only *http.Transport whenever IONOS_PINNED_CERT is set, so without the fix in
+// reapplyMTLSAfterPinning this test fails with the server never observing a client certificate.
+func TestNewIonosClient_MTLSWithCertPinning(t *testing.T) {
+	clientCertPEM, clientKeyPEM, _ := generateTestCertPEM(t, "provider-client", false)
+	serverCertPEM, serverKeyPEM, _ := generateTestCertPEM(t, "test-server", false)
+	otherCertPEM, _, _ := generateTestCertPEM(t, "other-server", false)
+
+	serverKeyPair, err := tls.X509KeyPair(serverCertPEM, serverKeyPEM)
+	require.NoError(t, err)
+
+	fingerprintOf := func(certPEM []byte) string {
+		block, _ := pem.Decode(certPEM)
+		require.NotNil(t, block)
+		sum := sha256.Sum256(block.Bytes)
+		return hex.EncodeToString(sum[:])
+	}
+
+	var sawClientCert bool
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawClientCert = r.TLS != nil && len(r.TLS.PeerCertificates) > 0
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{serverKeyPair},
+		ClientAuth:   tls.RequireAnyClientCert,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	creds := []byte(fmt.Sprintf(
+		`{"user": "username","password": "cGFzc3dvcmQ=", "client_cert": "%s", "client_key": "%s"}`,
+		b64(clientCertPEM), b64(clientKeyPEM),
+	))
+
+	t.Run("matching pinned fingerprint: client cert still presented", func(t *testing.T) {
+		sawClientCert = false
+		require.NoError(t, os.Setenv(ionos.IonosPinnedCertEnvVar, fingerprintOf(serverCertPEM)))
+		loadEnv()
+		defer func() {
+			require.NoError(t, os.Unsetenv(ionos.IonosPinnedCertEnvVar))
+			loadEnv()
+		}()
+
+		svc, err := NewIonosClients(creds)
+		require.NoError(t, err)
+		hc := svc.ComputeClient.GetConfig().HTTPClient
+		require.NotNil(t, hc)
+
+		resp, err := hc.Get(srv.URL)
+		require.NoError(t, err, "handshake must succeed: fingerprint matches and client cert is presented")
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.True(t, sawClientCert, "server must have received the client certificate")
+	})
+
+	t.Run("mismatched pinned fingerprint: connection rejected", func(t *testing.T) {
+		require.NoError(t, os.Setenv(ionos.IonosPinnedCertEnvVar, fingerprintOf(otherCertPEM)))
+		loadEnv()
+		defer func() {
+			require.NoError(t, os.Unsetenv(ionos.IonosPinnedCertEnvVar))
+			loadEnv()
+		}()
+
+		svc, err := NewIonosClients(creds)
+		require.NoError(t, err)
+		hc := svc.ComputeClient.GetConfig().HTTPClient
+		require.NotNil(t, hc)
+
+		_, err = hc.Get(srv.URL)
+		assert.Error(t, err, "handshake must fail when the pinned fingerprint does not match the server certificate")
+	})
 }
 
 func TestGetCoreResourceState(t *testing.T) {


### PR DESCRIPTION
## Summary
[ICNAS-870](https://hosting-jira.1and1.org/browse/ICNAS-870): crossplane-provider-ionoscloud should support mTLS for the cloud API endpoint.

- Adds optional `client_cert` / `client_key` / `ca_cert` fields (base64-encoded PEM, same convention as the existing `password` field) to the `ProviderConfig` credentials secret.
- When `client_cert`/`client_key` are set, the compute API client (`ComputeClient` only — DBaaS Postgres/Mongo are out of scope, different products/domains) presents that certificate for mutual TLS. `ca_cert` optionally augments the system root trust pool.
- Zero behavior change when unset: `ComputeClient.HTTPClient` stays `nil` (SDK defaults to `http.DefaultClient`), matching today's default path exactly.
- Fails closed rather than silently misconfiguring: cert-without-key (or vice versa), `ca_cert` without a client cert, and malformed base64/PEM all return a wrapped error instead of running with a partial/no-op config.
- Composes correctly with the existing `IONOS_PINNED_CERT` cert-pinning feature — the SDK's own `NewAPIClient` unconditionally overwrites the client's `Transport` when that env var is set, which would otherwise silently discard the mTLS setup. Reapplies the mTLS `tls.Config` (client cert + custom RootCAs) with the same fingerprint-verification logic pinning uses, so both features work together.

Not yet wired to any specific endpoint (e.g. the `cloudapi.paas-tunnel.ionos.cloud` internal tunnel) — this PR only adds the capability. Wiring an endpoint to actually use it, and retiring the `cloudapi-tunnel-proxy` nginx sidecar that currently does this mTLS handshake on the provider's behalf (ionos-cloud/deployment#16991), is tracked separately as [ICNAS-874](https://hosting-jira.1and1.org/browse/ICNAS-874).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/clients/...` — all existing cases pass unmodified; new cases cover valid mTLS (with/without CA), cert-without-key, key-without-cert, mismatched cert/key pair, malformed base64, invalid PEM, and `ca_cert`-without-client-cert
- [x] `go vet ./...`, `gofmt -l internal/clients/`
- [x] End-to-end `httptest`-based test verifying the mTLS+`IONOS_PINNED_CERT` interaction: client cert is actually presented to the server, and a mismatched pinned fingerprint is still rejected
- [ ] Manual validation against a real mTLS-enforcing endpoint (not yet done — this PR adds the capability, not a live integration)

https://claude.ai/code/session_01SZqEM9FNvK4VwCUqcomMfT