### PR TITLE
feat: make VM reboot timeout configurable via --vm-reboot-timeout

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -51,22 +51,24 @@ import (
 
 func main() {
 	var (
-		app                        = kingpin.New(filepath.Base(os.Args[0]), "IONOS Cloud support for Crossplane.").DefaultEnvars()
-		debug                      = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
-		uniqueNames                = app.Flag("unique-names", "Enable uniqueness name support for IONOS Cloud resources").Short('u').Default("false").Bool()
-		syncInterval               = app.Flag("sync", "Controller manager sync interval such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
-		pollInterval               = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for changes.").Default("1m").Duration()
-		leaderElection             = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
-		createGracePeriod          = app.Flag("create-grace-period", "Grace period for creation of IONOS Cloud resources.").Default("1m").Duration()
-		maxReconcileRate           = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
-		timeout                    = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("1h").Duration()
-		vmRebootTimeout            = app.Flag("vm-reboot-timeout", "Timeout to wait for a VM to reboot and report as ready again after a failover, for ServerSets using a custom state map. Must not exceed --timeout, or the wait will be cut short by the overall reconcile deadline.").Default("120m").Duration()
-		pollStateMetricInterval    = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
-		pollJitterPercentage       = app.Flag("poll-jitter-percentage", "Percentage of the poll interval by which an individual resource's poll interval may be randomly shifted, in either direction. 0 disables jitter, and it must be less than 100.").Default("0").Uint()
-		pollNotReady               = app.Flag("poll-not-ready", "Poll interval for a resource that is not ready yet, used in place of --poll while it is not ready. 0 leaves resources that are not ready on the --poll interval.").Default("0").Duration()
-		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
-		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
-		reconcileMap               = app.Flag("max-reconcile-rate-per-resource", "Overrides the max-reconcile-rate on a per resource basis. Use the Kind of the resource as the key.").PlaceHolder("nic:2").StringMap()
+		app                               = kingpin.New(filepath.Base(os.Args[0]), "IONOS Cloud support for Crossplane.").DefaultEnvars()
+		debug                             = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
+		uniqueNames                       = app.Flag("unique-names", "Enable uniqueness name support for IONOS Cloud resources").Short('u').Default("false").Bool()
+		syncInterval                      = app.Flag("sync", "Controller manager sync interval such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
+		pollInterval                      = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for changes.").Default("1m").Duration()
+		leaderElection                    = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").Envar("LEADER_ELECTION").Bool()
+		createGracePeriod                 = app.Flag("create-grace-period", "Grace period for creation of IONOS Cloud resources.").Default("1m").Duration()
+		maxReconcileRate                  = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
+		timeout                           = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("1h").Duration()
+		vmRebootTimeoutFlag               = app.Flag("vm-reboot-timeout", "Timeout to wait for a VM to reboot and report as ready again after a failover, for ServerSets using a custom state map. This budget is shared across every replica that needs to reboot within the same reconcile call (e.g. an image update touching all replicas) - it is not a fresh window per replica. If set higher than --timeout, the wait may be cut short by the overall reconcile deadline unless --extend-serverset-timeout-for-vm-reboot is also set.")
+		vmRebootTimeout                   = vmRebootTimeoutFlag.Default("120m").Duration()
+		extendServerSetTimeoutForVMReboot = app.Flag("extend-serverset-timeout-for-vm-reboot", "If true, widens the ServerSet controller's own reconcile timeout to be at least --vm-reboot-timeout, so a long VM reboot wait is not cut short by --timeout. Only affects ServerSet reconciles; every other resource kind keeps using --timeout unchanged.").Default("false").Bool()
+		pollStateMetricInterval           = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
+		pollJitterPercentage              = app.Flag("poll-jitter-percentage", "Percentage of the poll interval by which an individual resource's poll interval may be randomly shifted, in either direction. 0 disables jitter, and it must be less than 100.").Default("0").Uint()
+		pollNotReady                      = app.Flag("poll-not-ready", "Poll interval for a resource that is not ready yet, used in place of --poll while it is not ready. 0 leaves resources that are not ready on the --poll interval.").Default("0").Duration()
+		namespace                         = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
+		enableExternalSecretStores        = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
+		reconcileMap                      = app.Flag("max-reconcile-rate-per-resource", "Overrides the max-reconcile-rate on a per resource basis. Use the Kind of the resource as the key.").PlaceHolder("nic:2").StringMap()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	zl := zap.New(zap.UseDevMode(*debug))
@@ -82,6 +84,17 @@ func main() {
 	}
 
 	log.Debug("Starting", "sync-period", syncInterval.String(), "poll-interval", pollInterval.String(), "poll-jitter-percentage", *pollJitterPercentage, "poll-not-ready", pollNotReady.String(), "max-reconcile-rate", *maxReconcileRate, "debug", *debug)
+
+	// vmRebootTimeout's default (120m) is intentionally larger than timeout's default (1h) to
+	// preserve the pre-existing hardcoded behavior, so only warn when the user actually chose
+	// the value themselves - otherwise every deployment that never touches this flag (most of
+	// them, since it only matters for ServerSets using a custom state map) would see this on
+	// every startup.
+	if isFlagSetByUser(app, vmRebootTimeoutFlag, os.Args[1:]) && *vmRebootTimeout > *timeout && !*extendServerSetTimeoutForVMReboot {
+		log.Info("--vm-reboot-timeout exceeds --timeout and --extend-serverset-timeout-for-vm-reboot is not set; "+
+			"the VM reboot wait will effectively be capped at ~--timeout",
+			"vm-reboot-timeout", vmRebootTimeout.String(), "timeout", timeout.String())
+	}
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
@@ -136,7 +149,7 @@ func main() {
 
 	kingpin.FatalIfError(utils.ValidatePollJitterPercentage(*pollJitterPercentage), "Invalid --poll-jitter-percentage")
 
-	options := utils.NewConfigurationOptions(*timeout, *createGracePeriod, *vmRebootTimeout, *uniqueNames, ctrlOpts)
+	options := utils.NewConfigurationOptions(*timeout, *createGracePeriod, *vmRebootTimeout, *extendServerSetTimeoutForVMReboot, *uniqueNames, ctrlOpts)
 	options.PollJitterPercentage = *pollJitterPercentage
 	options.NotReadyPollInterval = *pollNotReady
 	if len(*reconcileMap) > 0 {
@@ -151,4 +164,24 @@ func main() {
 
 	kingpin.FatalIfError(controller.Setup(mgr, options), "Cannot setup IONOS Cloud controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
+}
+
+// isFlagSetByUser reports whether flag was explicitly provided in args or via its envar, as
+// opposed to just carrying its default value.
+func isFlagSetByUser(app *kingpin.Application, flag *kingpin.FlagClause, args []string) bool {
+	pctx, err := app.ParseContext(args)
+	if err != nil {
+		return false
+	}
+	// HasEnvarValue is only reliable once ParseContext has resolved the flag's default-envar
+	// name as a side effect of Application.init, hence the ordering above.
+	if flag.HasEnvarValue() {
+		return true
+	}
+	for _, e := range pctx.Elements {
+		if e.Clause == flag {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -60,7 +60,7 @@ func main() {
 		createGracePeriod                 = app.Flag("create-grace-period", "Grace period for creation of IONOS Cloud resources.").Default("1m").Duration()
 		maxReconcileRate                  = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
 		timeout                           = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("1h").Duration()
-		vmRebootTimeoutFlag               = app.Flag("vm-reboot-timeout", "Timeout to wait for a VM to reboot and report as ready again after a failover, for ServerSets using a custom state map. This budget is shared across every replica that needs to reboot within the same reconcile call (e.g. an image update touching all replicas) - it is not a fresh window per replica. If set higher than --timeout, the wait may be cut short by the overall reconcile deadline unless --extend-serverset-timeout-for-vm-reboot is also set.")
+		vmRebootTimeoutFlag               = app.Flag("vm-reboot-timeout", "Timeout to wait for a VM to reboot and report as ready again after a failover, for ServerSets using a custom state map. This budget is shared across every replica that needs to reboot within the same reconcile call (e.g. an image update touching all replicas) - it is not a fresh window per replica. If set higher than --timeout, --extend-serverset-timeout-for-vm-reboot must also be set, or the provider will refuse to start.")
 		vmRebootTimeout                   = vmRebootTimeoutFlag.Default("120m").Duration()
 		extendServerSetTimeoutForVMReboot = app.Flag("extend-serverset-timeout-for-vm-reboot", "If true, widens the ServerSet controller's own reconcile timeout to be at least --vm-reboot-timeout, so a long VM reboot wait is not cut short by --timeout. Only affects ServerSet reconciles; every other resource kind keeps using --timeout unchanged.").Default("false").Bool()
 		pollStateMetricInterval           = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
@@ -86,14 +86,17 @@ func main() {
 	log.Debug("Starting", "sync-period", syncInterval.String(), "poll-interval", pollInterval.String(), "poll-jitter-percentage", *pollJitterPercentage, "poll-not-ready", pollNotReady.String(), "max-reconcile-rate", *maxReconcileRate, "debug", *debug)
 
 	// vmRebootTimeout's default (120m) is intentionally larger than timeout's default (1h) to
-	// preserve the pre-existing hardcoded behavior, so only warn when the user actually chose
-	// the value themselves - otherwise every deployment that never touches this flag (most of
-	// them, since it only matters for ServerSets using a custom state map) would see this on
-	// every startup.
+	// preserve the pre-existing hardcoded behavior, so only validate when the user actually
+	// chose the value themselves - otherwise every deployment that never touches this flag
+	// (most of them, since it only matters for ServerSets using a custom state map) would fail
+	// to start. There's no legitimate reason to explicitly set vmRebootTimeout above timeout
+	// without also enabling extendServerSetTimeoutForVMReboot: without it, the value is
+	// silently capped and has no effect at all, so this can only ever be a mistake.
 	if isFlagSetByUser(app, vmRebootTimeoutFlag, os.Args[1:]) && *vmRebootTimeout > *timeout && !*extendServerSetTimeoutForVMReboot {
-		log.Info("--vm-reboot-timeout exceeds --timeout and --extend-serverset-timeout-for-vm-reboot is not set; "+
-			"the VM reboot wait will effectively be capped at ~--timeout",
-			"vm-reboot-timeout", vmRebootTimeout.String(), "timeout", timeout.String())
+		kingpin.Fatalf("--vm-reboot-timeout (%s) exceeds --timeout (%s) but --extend-serverset-timeout-for-vm-reboot is not set; "+
+			"the VM reboot wait would be silently capped at ~--timeout and have no effect. "+
+			"Either lower --vm-reboot-timeout or pass --extend-serverset-timeout-for-vm-reboot",
+			vmRebootTimeout, timeout)
 	}
 
 	cfg, err := ctrl.GetConfig()

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -152,9 +152,11 @@ func main() {
 
 	kingpin.FatalIfError(utils.ValidatePollJitterPercentage(*pollJitterPercentage), "Invalid --poll-jitter-percentage")
 
-	options := utils.NewConfigurationOptions(*timeout, *createGracePeriod, *vmRebootTimeout, *extendServerSetTimeoutForVMReboot, *uniqueNames, ctrlOpts)
+	options := utils.NewConfigurationOptions(*timeout, *createGracePeriod, *uniqueNames, ctrlOpts)
 	options.PollJitterPercentage = *pollJitterPercentage
 	options.NotReadyPollInterval = *pollNotReady
+	options.VMRebootTimeout = *vmRebootTimeout
+	options.ExtendServerSetTimeoutForVMReboot = *extendServerSetTimeoutForVMReboot
 	if len(*reconcileMap) > 0 {
 		options.MaxReconcilesPerResource = make(map[string]int, len(*reconcileMap))
 		// convert to lowercase and convert string to int

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -60,6 +60,7 @@ func main() {
 		createGracePeriod          = app.Flag("create-grace-period", "Grace period for creation of IONOS Cloud resources.").Default("1m").Duration()
 		maxReconcileRate           = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
 		timeout                    = app.Flag("timeout", "Timeout duration cumulatively for all the calls happening in the reconciliation functions.").Default("1h").Duration()
+		vmRebootTimeout            = app.Flag("vm-reboot-timeout", "Timeout to wait for a VM to reboot and report as ready again after a failover, for ServerSets using a custom state map. Must not exceed --timeout, or the wait will be cut short by the overall reconcile deadline.").Default("120m").Duration()
 		pollStateMetricInterval    = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
 		pollJitterPercentage       = app.Flag("poll-jitter-percentage", "Percentage of the poll interval by which an individual resource's poll interval may be randomly shifted, in either direction. 0 disables jitter, and it must be less than 100.").Default("0").Uint()
 		pollNotReady               = app.Flag("poll-not-ready", "Poll interval for a resource that is not ready yet, used in place of --poll while it is not ready. 0 leaves resources that are not ready on the --poll interval.").Default("0").Duration()
@@ -135,7 +136,7 @@ func main() {
 
 	kingpin.FatalIfError(utils.ValidatePollJitterPercentage(*pollJitterPercentage), "Invalid --poll-jitter-percentage")
 
-	options := utils.NewConfigurationOptions(*timeout, *createGracePeriod, *uniqueNames, ctrlOpts)
+	options := utils.NewConfigurationOptions(*timeout, *createGracePeriod, *vmRebootTimeout, *uniqueNames, ctrlOpts)
 	options.PollJitterPercentage = *pollJitterPercentage
 	options.NotReadyPollInterval = *pollNotReady
 	if len(*reconcileMap) > 0 {

--- a/cmd/provider/main_test.go
+++ b/cmd/provider/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+func TestIsFlagSetByUser(t *testing.T) {
+	newApp := func() (*kingpin.Application, *kingpin.FlagClause) {
+		app := kingpin.New("test", "").DefaultEnvars()
+		flag := app.Flag("vm-reboot-timeout", "")
+		flag.Default("120m").Duration()
+		return app, flag
+	}
+
+	t.Run("not set falls back to default", func(t *testing.T) {
+		app, flag := newApp()
+		assert.False(t, isFlagSetByUser(app, flag, []string{}))
+	})
+
+	t.Run("set explicitly on the command line", func(t *testing.T) {
+		app, flag := newApp()
+		assert.True(t, isFlagSetByUser(app, flag, []string{"--vm-reboot-timeout=3h"}))
+	})
+
+	t.Run("a different flag being set does not count", func(t *testing.T) {
+		app, flag := newApp()
+		app.Flag("timeout", "").Default("1h").Duration()
+		assert.False(t, isFlagSetByUser(app, flag, []string{"--timeout=2h"}))
+	})
+
+	t.Run("set via envar", func(t *testing.T) {
+		app, flag := newApp()
+		// DefaultEnvars derives the name as "<app.Name>_<flag.name>", uppercased.
+		t.Setenv("TEST_VM_REBOOT_TIMEOUT", "3h")
+		assert.True(t, isFlagSetByUser(app, flag, []string{}))
+	})
+
+	t.Run("unparseable args fail closed", func(t *testing.T) {
+		app, flag := newApp()
+		assert.False(t, isFlagSetByUser(app, flag, []string{"--does-not-exist"}))
+	})
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [Unreleased]
+### Features:
+- Make the VM-reboot wait after a ServerSet failover configurable (`--vm-reboot-timeout`, default `120m`, same as the previous hardcoded value), with an opt-in `--extend-serverset-timeout-for-vm-reboot` flag to widen the ServerSet controller's own reconcile timeout to accommodate it when needed.
+
+## [1.2.6] (August 2026)
+### Fixes:
+- Derive replica index from its label instead of list position in `updateOrRecreateVolumes`, since `ReplicaStatuses` entries aren't ordered by index.
+- Treat a `NicMultiQueue` change as requiring a failover (VM reboot), since the Cloud API always reboots the VM to apply it.
+
 ## [1.2.5] (August 2026)
 ### Fixes:
 - Omit `nodeCount` from the k8s nodepool update request when autoscaling is enabled, so the autoscaled node count is no longer reset on update.

--- a/internal/controller/serverset/serverset.go
+++ b/internal/controller/serverset/serverset.go
@@ -76,6 +76,9 @@ type connector struct {
 	kubeConfigmapController kubeConfigmapControlManager
 	usage                   resource.Tracker
 	log                     logging.Logger
+	// vmRebootTimeout is how long to wait for a VM to reboot and report as ready again after a
+	// failover, for ServerSets using a custom state map.
+	vmRebootTimeout time.Duration
 }
 
 // Connect typically produces an ExternalClient by:
@@ -101,6 +104,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		serverController:       c.serverController,
 		firewallRuleController: c.firewallRuleController,
 		configMapController:    c.kubeConfigmapController,
+		vmRebootTimeout:        c.vmRebootTimeout,
 	}, err
 }
 
@@ -116,6 +120,9 @@ type external struct {
 	firewallRuleController kubeFirewallRuleControlManager
 	configMapController    kubeConfigmapControlManager
 	log                    logging.Logger
+	// vmRebootTimeout is how long to wait for a VM to reboot and report as ready again after a
+	// failover, for ServerSets using a custom state map.
+	vmRebootTimeout time.Duration
 }
 
 func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) { // nolint:gocyclo
@@ -561,7 +568,7 @@ func (e *external) updateServersFromTemplate(ctx context.Context, cr *v1alpha1.S
 				e.log.Info("Server has been updated and uses custom state map, waiting for reboot to finish", "serverset", cr.Name, "server", servers[idx].Name)
 				// After reboot, wait for server to be in running state again before proceeding to next replica
 				if err := kube.WaitForResource(
-					ctx, kube.VMRebootTimeout, func(ctx context.Context, mapName, mapNamespace string) (bool, error) {
+					ctx, e.vmRebootTimeout, func(ctx context.Context, mapName, mapNamespace string) (bool, error) {
 						return e.isVMSoftwareRunning(ctx, requestTimestamp, servers[idx].Name, mapName, mapNamespace)
 					}, cr.Spec.ForProvider.Template.Spec.StateMap.Name, cr.Spec.ForProvider.Template.Spec.StateMap.Namespace,
 				); err != nil {
@@ -674,7 +681,7 @@ func (e *external) updateWithFailoverOrchestration(ctx context.Context, cr *v1al
 			return fmt.Errorf("could not find server with replica index %d of serverset %s to wait for its reboot", replicaIndex, cr.Name)
 		}
 		if err := kube.WaitForResource(
-			ctx, kube.VMRebootTimeout, func(ctx context.Context, mapName, mapNamespace string) (bool, error) {
+			ctx, e.vmRebootTimeout, func(ctx context.Context, mapName, mapNamespace string) (bool, error) {
 				return e.isVMSoftwareRunning(ctx, requestTimestamp, serverObj.Name, mapName, mapNamespace)
 			}, cr.Spec.ForProvider.Template.Spec.StateMap.Name, cr.Spec.ForProvider.Template.Spec.StateMap.Namespace,
 		); err != nil {

--- a/internal/controller/serverset/setup.go
+++ b/internal/controller/serverset/setup.go
@@ -32,6 +32,10 @@ func SetupServerSet(mgr ctrl.Manager, opts *utils.ConfigurationOptions) error {
 		kube: mgr.GetClient(),
 		log:  logger,
 	}
+	reconcileTimeout := opts.GetTimeout()
+	if opts.GetExtendServerSetTimeoutForVMReboot() {
+		reconcileTimeout = max(reconcileTimeout, opts.GetVMRebootTimeout())
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
 		WithEventFilter(utils.DesiredStateChanged()).
@@ -71,7 +75,7 @@ func SetupServerSet(mgr ctrl.Manager, opts *utils.ConfigurationOptions) error {
 			managed.WithReferenceResolver(managed.NewAPISimpleReferenceResolver(mgr.GetClient())),
 			managed.WithInitializers(),
 			managed.WithPollInterval(opts.GetPollInterval()),
-			managed.WithTimeout(opts.GetTimeout()),
+			managed.WithTimeout(reconcileTimeout),
 			managed.WithCreationGracePeriod(opts.GetCreationGracePeriod()),
 			managed.WithLogger(logger.WithValues("controller", name)),
 			managed.WithPollIntervalHook(opts.PollIntervalHook()),

--- a/internal/controller/serverset/setup.go
+++ b/internal/controller/serverset/setup.go
@@ -46,6 +46,7 @@ func SetupServerSet(mgr ctrl.Manager, opts *utils.ConfigurationOptions) error {
 			managed.WithExternalConnecter(&connector{
 				kube:                    mgr.GetClient(),
 				kubeConfigmapController: &mapController,
+				vmRebootTimeout:         opts.GetVMRebootTimeout(),
 				bootVolumeController: &kubeBootVolumeController{
 					kube:          mgr.GetClient(),
 					log:           logger,

--- a/internal/utils/configuration.go
+++ b/internal/utils/configuration.go
@@ -10,11 +10,12 @@ import (
 // ConfigurationOptions are options used in setting the provider
 // and the controllers of the provider.
 type ConfigurationOptions struct {
-	CreationGracePeriod      time.Duration
-	Timeout                  time.Duration
-	VMRebootTimeout          time.Duration
-	IsUniqueNamesEnabled     bool
-	MaxReconcilesPerResource map[string]int
+	CreationGracePeriod               time.Duration
+	Timeout                           time.Duration
+	VMRebootTimeout                   time.Duration
+	ExtendServerSetTimeoutForVMReboot bool
+	IsUniqueNamesEnabled              bool
+	MaxReconcilesPerResource          map[string]int
 	// PollJitterPercentage is the percentage of its poll interval by which a single
 	// resource's poll interval is randomly shifted, in either direction.
 	PollJitterPercentage uint
@@ -26,13 +27,14 @@ type ConfigurationOptions struct {
 }
 
 // NewConfigurationOptions sets fields for ConfigurationOptions and return a new ConfigurationOptions
-func NewConfigurationOptions(timeout, createGracePeriod, vmRebootTimeout time.Duration, uniqueNamesEnable bool, ctrlOpts controller.Options) *ConfigurationOptions {
+func NewConfigurationOptions(timeout, createGracePeriod, vmRebootTimeout time.Duration, extendServerSetTimeoutForVMReboot, uniqueNamesEnable bool, ctrlOpts controller.Options) *ConfigurationOptions {
 	return &ConfigurationOptions{
-		CreationGracePeriod:  createGracePeriod,
-		IsUniqueNamesEnabled: uniqueNamesEnable,
-		Timeout:              timeout,
-		VMRebootTimeout:      vmRebootTimeout,
-		CtrlOpts:             ctrlOpts,
+		CreationGracePeriod:               createGracePeriod,
+		IsUniqueNamesEnabled:              uniqueNamesEnable,
+		Timeout:                           timeout,
+		VMRebootTimeout:                   vmRebootTimeout,
+		ExtendServerSetTimeoutForVMReboot: extendServerSetTimeoutForVMReboot,
+		CtrlOpts:                          ctrlOpts,
 	}
 }
 
@@ -82,6 +84,14 @@ func (o *ConfigurationOptions) GetVMRebootTimeout() time.Duration {
 		return 0
 	}
 	return o.VMRebootTimeout
+}
+
+// GetExtendServerSetTimeoutForVMReboot returns the value for the ExtendServerSetTimeoutForVMReboot option
+func (o *ConfigurationOptions) GetExtendServerSetTimeoutForVMReboot() bool {
+	if o == nil {
+		return false
+	}
+	return o.ExtendServerSetTimeoutForVMReboot
 }
 
 // GetIsUniqueNamesEnabled returns the value for the IsUniqueNamesEnabled option

--- a/internal/utils/configuration.go
+++ b/internal/utils/configuration.go
@@ -12,6 +12,7 @@ import (
 type ConfigurationOptions struct {
 	CreationGracePeriod      time.Duration
 	Timeout                  time.Duration
+	VMRebootTimeout          time.Duration
 	IsUniqueNamesEnabled     bool
 	MaxReconcilesPerResource map[string]int
 	// PollJitterPercentage is the percentage of its poll interval by which a single
@@ -25,11 +26,12 @@ type ConfigurationOptions struct {
 }
 
 // NewConfigurationOptions sets fields for ConfigurationOptions and return a new ConfigurationOptions
-func NewConfigurationOptions(timeout, createGracePeriod time.Duration, uniqueNamesEnable bool, ctrlOpts controller.Options) *ConfigurationOptions {
+func NewConfigurationOptions(timeout, createGracePeriod, vmRebootTimeout time.Duration, uniqueNamesEnable bool, ctrlOpts controller.Options) *ConfigurationOptions {
 	return &ConfigurationOptions{
 		CreationGracePeriod:  createGracePeriod,
 		IsUniqueNamesEnabled: uniqueNamesEnable,
 		Timeout:              timeout,
+		VMRebootTimeout:      vmRebootTimeout,
 		CtrlOpts:             ctrlOpts,
 	}
 }
@@ -72,6 +74,14 @@ func (o *ConfigurationOptions) GetTimeout() time.Duration {
 		return 0
 	}
 	return o.Timeout
+}
+
+// GetVMRebootTimeout returns the value for the VMRebootTimeout option
+func (o *ConfigurationOptions) GetVMRebootTimeout() time.Duration {
+	if o == nil {
+		return 0
+	}
+	return o.VMRebootTimeout
 }
 
 // GetIsUniqueNamesEnabled returns the value for the IsUniqueNamesEnabled option

--- a/internal/utils/configuration.go
+++ b/internal/utils/configuration.go
@@ -27,14 +27,12 @@ type ConfigurationOptions struct {
 }
 
 // NewConfigurationOptions sets fields for ConfigurationOptions and return a new ConfigurationOptions
-func NewConfigurationOptions(timeout, createGracePeriod, vmRebootTimeout time.Duration, extendServerSetTimeoutForVMReboot, uniqueNamesEnable bool, ctrlOpts controller.Options) *ConfigurationOptions {
+func NewConfigurationOptions(timeout, createGracePeriod time.Duration, uniqueNamesEnable bool, ctrlOpts controller.Options) *ConfigurationOptions {
 	return &ConfigurationOptions{
-		CreationGracePeriod:               createGracePeriod,
-		IsUniqueNamesEnabled:              uniqueNamesEnable,
-		Timeout:                           timeout,
-		VMRebootTimeout:                   vmRebootTimeout,
-		ExtendServerSetTimeoutForVMReboot: extendServerSetTimeoutForVMReboot,
-		CtrlOpts:                          ctrlOpts,
+		CreationGracePeriod:  createGracePeriod,
+		IsUniqueNamesEnabled: uniqueNamesEnable,
+		Timeout:              timeout,
+		CtrlOpts:             ctrlOpts,
 	}
 }
 

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -14,7 +14,9 @@ import (
 // ResourceReadyTimeout time to wait for resource to be ready
 const ResourceReadyTimeout = 50 * time.Minute
 
-// ServerSetReadyTimeout time to wait for serverset to be ready
+// ServerSetReadyTimeout time to wait for serverset to be ready. Only used on initial creation of the
+// child ServerSet CR (StatefulServerSet's Ensure); subsequent updates (e.g. image-update reboots) go
+// through Update, which does not block on readiness, so this timeout is never in play for those.
 const ServerSetReadyTimeout = 3 * time.Hour
 
 // ErrExternalCreateFailed error when external create fails, so we know to delete kube object

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -14,9 +14,6 @@ import (
 // ResourceReadyTimeout time to wait for resource to be ready
 const ResourceReadyTimeout = 50 * time.Minute
 
-// VMRebootTimeout time to wait for a VM to reboot and report as ready after a failover
-const VMRebootTimeout = 120 * time.Minute
-
 // ServerSetReadyTimeout time to wait for serverset to be ready
 const ServerSetReadyTimeout = 3 * time.Hour
 

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -33,8 +33,8 @@ func WaitForResource(ctx context.Context, timeoutInMinutes time.Duration, fn IsR
 		return fmt.Errorf("name is empty")
 	}
 	pollInterval := 2 * time.Second
-	return wait.PollUntilContextTimeout(ctx, pollInterval, timeoutInMinutes, true, func(context.Context) (bool, error) {
-		return fn(ctx, name, namespace)
+	return wait.PollUntilContextTimeout(ctx, pollInterval, timeoutInMinutes, true, func(pollCtx context.Context) (bool, error) {
+		return fn(pollCtx, name, namespace)
 	})
 }
 


### PR DESCRIPTION

### Description of your changes

This PR adds:

- a `--vm-reboot-timeout` flag to be able to configure the amount of time waited after a VM has been rebooted when using the `statemap` feature
- a boolean flag `--extend-serverset-timeout-for-vm-reboot` to optionally be able to extend the timeout of the **`ServerSet` controller**, without needing to change the global timeout _for all other controllers_. This is necessary, otherwise a `--vm-reboot-timeout` longer than the global `--timeout` would not actually be applied... This is a compromise, to avoid having to raise `--timeout` for all controllers to unnecessarily high values.
- a check to exit early with an error at startup when `--vm-reboot-timeout` is configured manually beyond the `--timeout` without also setting `--extend-serverset-timeout-for-vm-reboot`. This is intended to guard against unintentional misconfiguration, and will **only** fire if the user _manually specifies the `--vm-reboot-timeout` flag_, and never with the default configuration (which already has --timeout lower than --vm-reboot-timeout). One could instead log a warning, but I think it's likely that would not be noticed and hence not stop accidental misconfiguration...
- a fix for `WaitForResource` in 3c814471d74ca76931490cd3aba5b1bffc900b22. The calculated deadline wasn't actually properly passed to the function callback, it always received the overall outer context without the more specific deadline. This should not matter, because the callbacks usually complete fast.

Instead of this (a bit over-specific) `--extend-serverset-timeout-for-vm-reboot` flag, one could also introduce a `--timeout-per-resource` flag mirroring `--max-reconcile-rate-per-resource`. That would make the timeout for any controller in this provider configurable, and then one just has to know to increase the timeout for SSet.
If you'd prefer that solution, let me know.

## Checklist

I have:

- [x] Add PR name as appropriate (e.g. `feat`/`fix`/`doc`/`test`/`refactor`)
- [x] Run `make reviewable` and `make crds.clean` to ensure the PR is ready for review
- [x] Add or update tests (if applicable)
- [ ] Add or update Documentation using `make docs.update` (if applicable)
- [x] Update `docs/CHANGELOG.md` file (label: `upcoming release`)
- [x] Check Sonar Cloud Scan
